### PR TITLE
Removing common_rosdeps as a dependency

### DIFF
--- a/camera_calibration_parsers/manifest.xml
+++ b/camera_calibration_parsers/manifest.xml
@@ -11,7 +11,6 @@
 
   <depend package="roscpp"/>
   <depend package="sensor_msgs"/>
-  <depend package="common_rosdeps"/>
 
   <rosdep name="yaml-cpp"/>
 
@@ -19,7 +18,4 @@
     <cpp cflags="-I${prefix}/include" lflags="-Wl,-rpath,${prefix}/lib -L${prefix}/lib -lcamera_calibration_parsers" />
   </export>
 
-  <platform os="ubuntu" version="9.04"/>
-  <platform os="ubuntu" version="9.10"/>
-  <platform os="ubuntu" version="10.04"/>
 </package>


### PR DESCRIPTION
Also cleaning up unused platform tags. 
