### PR TITLE
Missing link flags exposed on OS X

### DIFF
--- a/polled_camera/CMakeLists.txt
+++ b/polled_camera/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(include
 
 add_library(${PROJECT_NAME} src/publication_server.cpp)
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencpp)
-target_link_libraries(${PROJECT_NAME} ${rosconsole_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 install(TARGETS ${PROJECT_NAME}
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
@@ -34,7 +34,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 add_executable(poller src/poller.cpp)
 target_link_libraries(poller ${PROJECT_NAME}
-                             ${roscpp_LIBRARIES}
+                             ${catkin_LIBRARIES}
 )
 install(TARGETS poller
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}


### PR DESCRIPTION
When building on OS X I get:

```
==> Processing catkin package: 'polled_camera'
==> Creating build directory: 'build_isolated/polled_camera'
==> Building with env: '/Users/william/ros_catkin_ws/install_isolated/env_cached.sh'
==> cmake /Users/william/ros_catkin_ws/src/polled_camera -DCATKIN_STATIC_ENV=1 -DCATKIN_DEVEL_PREFIX=/Users/william/ros_catkin_ws/devel_isolated/polled_camera -DCMAKE_INSTALL_PREFIX=/Users/william/ros_catkin_ws/install_isolated
==> make -j4 in '/Users/william/ros_catkin_ws/build_isolated/polled_camera'
Scanning dependencies of target polled_camera_genpy
Scanning dependencies of target polled_camera_genlisp
Scanning dependencies of target polled_camera_gencpp
[ 33%] [ 33%] [ 50%] Generating Python code from SRV polled_camera/GetPolledImage
Generating Lisp code from polled_camera/GetPolledImage.srv
Generating C++ code from polled_camera/GetPolledImage.srv
[ 50%] Built target polled_camera_genlisp
[ 66%] Generating Python srv __init__.py for polled_camera
[ 66%] Built target polled_camera_genpy
[ 66%] Built target polled_camera_gencpp
Scanning dependencies of target polled_camera
[ 83%] Building CXX object CMakeFiles/polled_camera.dir/src/publication_server.cpp.o
Linking CXX shared library /Users/william/ros_catkin_ws/devel_isolated/polled_camera/lib/libpolled_camera.dylib
Undefined symbols for architecture x86_64:
  "image_transport::ImageTransport::advertiseCamera(std::string const&, unsigned int, boost::function<void (image_transport::SingleSubscriberPublisher const&)> const&, boost::function<void (image_transport::SingleSubscriberPublisher const&)> const&, boost::function<void (ros::SingleSubscriberPublisher const&)> const&, boost::function<void (ros::SingleSubscriberPublisher const&)> const&, boost::shared_ptr<void> const&, bool)", referenced from:
      polled_camera::PublicationServer::Impl::requestCallback(polled_camera::GetPolledImageRequest_<std::allocator<void> >&, polled_camera::GetPolledImageResponse_<std::allocator<void> >&) in publication_server.cpp.o
  "image_transport::ImageTransport::ImageTransport(ros::NodeHandle const&)", referenced from:
      polled_camera::PublicationServer::Impl::Impl(ros::NodeHandle const&) in publication_server.cpp.o
  "image_transport::ImageTransport::~ImageTransport()", referenced from:
      polled_camera::PublicationServer::Impl::~Impl() in publication_server.cpp.o
      polled_camera::PublicationServer::Impl::Impl(ros::NodeHandle const&) in publication_server.cpp.o
  "ros::NodeHandle::advertiseService(ros::AdvertiseServiceOptions&)", referenced from:
      ros::ServiceServer ros::NodeHandle::advertiseService<polled_camera::PublicationServer::Impl, polled_camera::GetPolledImageRequest_<std::allocator<void> >, polled_camera::GetPolledImageResponse_<std::allocator<void> > >(std::string const&, bool (polled_camera::PublicationServer::Impl::*)(polled_camera::GetPolledImageRequest_<std::allocator<void> >&, polled_camera::GetPolledImageResponse_<std::allocator<void> >&), boost::shared_ptr<polled_camera::PublicationServer::Impl> const&) in publication_server.cpp.o
  "ros::ServiceServer::shutdown()", referenced from:
      polled_camera::PublicationServer::Impl::unadvertise() in publication_server.cpp.o
  "ros::ServiceServer::~ServiceServer()", referenced from:
      polled_camera::PublicationServer::PublicationServer(std::string const&, ros::NodeHandle&, boost::function<void (polled_camera::GetPolledImageRequest_<std::allocator<void> >&, polled_camera::GetPolledImageResponse_<std::allocator<void> >&, sensor_msgs::Image_<std::allocator<void> >&, sensor_msgs::CameraInfo_<std::allocator<void> >&)> const&, boost::shared_ptr<void> const&) in publication_server.cpp.o
      polled_camera::PublicationServer::Impl::~Impl() in publication_server.cpp.o
      polled_camera::PublicationServer::Impl::Impl(ros::NodeHandle const&) in publication_server.cpp.o
  "ros::serialization::throwStreamOverrun()", referenced from:
      void ros::serialization::Serializer<std::string>::write<ros::serialization::OStream>(ros::serialization::OStream&, std::string const&) in publication_server.cpp.o
      void ros::serialization::Serializer<unsigned int>::write<ros::serialization::OStream>(ros::serialization::OStream&, unsigned int) in publication_server.cpp.o
      void ros::serialization::Serializer<unsigned char>::write<ros::serialization::OStream>(ros::serialization::OStream&, unsigned char) in publication_server.cpp.o
      void ros::serialization::Serializer<unsigned char>::read<ros::serialization::IStream>(ros::serialization::IStream&, unsigned char&) in publication_server.cpp.o
      void ros::serialization::Serializer<unsigned int>::read<ros::serialization::IStream>(ros::serialization::IStream&, unsigned int&) in publication_server.cpp.o
      void ros::serialization::Serializer<int>::read<ros::serialization::IStream>(ros::serialization::IStream&, int&) in publication_server.cpp.o
      void ros::serialization::Serializer<std::string>::read<ros::serialization::IStream>(ros::serialization::IStream&, std::string&) in publication_server.cpp.o
      ...
  "image_transport::CameraPublisher::publish(sensor_msgs::Image_<std::allocator<void> > const&, sensor_msgs::CameraInfo_<std::allocator<void> > const&) const", referenced from:
      polled_camera::PublicationServer::Impl::requestCallback(polled_camera::GetPolledImageRequest_<std::allocator<void> >&, polled_camera::GetPolledImageResponse_<std::allocator<void> >&) in publication_server.cpp.o
  "image_transport::CameraPublisher::getTopic() const", referenced from:
      polled_camera::PublicationServer::Impl::requestCallback(polled_camera::GetPolledImageRequest_<std::allocator<void> >&, polled_camera::GetPolledImageResponse_<std::allocator<void> >&) in publication_server.cpp.o
  "image_transport::CameraPublisher::operator void*() const", referenced from:
      polled_camera::PublicationServer::Impl::requestCallback(polled_camera::GetPolledImageRequest_<std::allocator<void> >&, polled_camera::GetPolledImageResponse_<std::allocator<void> >&) in publication_server.cpp.o
  "image_transport::SingleSubscriberPublisher::getNumSubscribers() const", referenced from:
      polled_camera::PublicationServer::Impl::disconnectCallback(image_transport::SingleSubscriberPublisher const&) in publication_server.cpp.o
  "image_transport::SingleSubscriberPublisher::getTopic() const", referenced from:
      polled_camera::PublicationServer::Impl::disconnectCallback(image_transport::SingleSubscriberPublisher const&) in publication_server.cpp.o
  "ros::ServiceServer::getService() const", referenced from:
      polled_camera::PublicationServer::getService() const in publication_server.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [/Users/william/ros_catkin_ws/devel_isolated/polled_camera/lib/libpolled_camera.dylib] Error 1
make[1]: *** [CMakeFiles/polled_camera.dir/all] Error 2
make: *** [all] Error 2

<== Failed to process package 'polled_camera': 
  Command '/Users/william/ros_catkin_ws/install_isolated/env_cached.sh make -j4' returned non-zero exit status 2
Command failed, exiting.
```

A cleaner solution might be to be more explicit about the libraries to link rather than using catkin_LIBRARIES, but this works.
