### PR TITLE
Detect yaml-cpp >= 0.5 and use the new API.

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -11,6 +11,12 @@ catkin_package(
   CATKIN_DEPENDS sensor_msgs
 )
 
+find_package(PkgConfig)
+pkg_check_modules(NEW_YAMLCPP yaml-cpp>=0.5)
+if(NEW_YAMLCPP_FOUND)
+add_definitions(-DHAVE_NEW_YAMLCPP)
+endif(NEW_YAMLCPP_FOUND)
+
 # define the library
 add_library(${PROJECT_NAME}
   src/parse.cpp


### PR DESCRIPTION
The current release of yaml-cpp, 0.5[.1], has an incompatible API.
There is no version information in the headers, so I'm using the
version from pkg-config to figure out which API is appropriate.
