### PR TITLE
check for CATKIN_ENABLE_TESTING

### DIFF
--- a/camera_info_manager/CMakeLists.txt
+++ b/camera_info_manager/CMakeLists.txt
@@ -33,10 +33,12 @@ install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
-# Unit test uses gtest, but needs rostest to create a ROS environment.
-# Hence, it must be created as a normal executable, not using
-# catkin_add_gtest() which runs an additional test without rostest.
-add_executable(unit_test tests/unit_test.cpp)
-target_link_libraries(unit_test ${PROJECT_NAME} ${GTEST_LIBRARIES})
+if(CATKIN_ENABLE_TESTING)
+  # Unit test uses gtest, but needs rostest to create a ROS environment.
+  # Hence, it must be created as a normal executable, not using
+  # catkin_add_gtest() which runs an additional test without rostest.
+  add_executable(unit_test tests/unit_test.cpp)
+  target_link_libraries(unit_test ${PROJECT_NAME} ${GTEST_LIBRARIES})
 
-add_rostest(tests/unit_test.test)
+  add_rostest(tests/unit_test.test)
+endif()

--- a/camera_info_manager/package.xml
+++ b/camera_info_manager/package.xml
@@ -18,7 +18,7 @@
   <url type="bugtracker">https://github.com/ros-perception/image_common/issues</url>
   <url type="repository">https://github.com/ros-perception/image_common</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>boost</build_depend>
   <build_depend>camera_calibration_parsers</build_depend>


### PR DESCRIPTION
Since version 0.5.68, catkin provides to optionally configure tests. This commit adjusts the CMakeLists.txt to opt-in the tests.
