### PR TITLE
camera_info_manager: Adding public member function to manually set camera_info

### DIFF
--- a/camera_info_manager/include/camera_info_manager/camera_info_manager.h
+++ b/camera_info_manager/include/camera_info_manager/camera_info_manager.h
@@ -185,6 +185,7 @@ class CameraInfoManager
   std::string resolveURL(const std::string &url,
                          const std::string &cname);
   bool setCameraName(const std::string &cname);
+  bool setCameraInfo(const sensor_msgs::CameraInfo &camera_info);
   bool validateURL(const std::string &url);
 
  private:
@@ -214,8 +215,8 @@ class CameraInfoManager
   bool saveCalibrationFile(const sensor_msgs::CameraInfo &new_info,
                            const std::string &filename,
                            const std::string &cname);
-  bool setCameraInfo(sensor_msgs::SetCameraInfo::Request &req,
-                     sensor_msgs::SetCameraInfo::Response &rsp);
+  bool setCameraInfoService(sensor_msgs::SetCameraInfo::Request &req,
+                            sensor_msgs::SetCameraInfo::Response &rsp);
 
   /** @brief mutual exclusion lock for private data
    *

--- a/camera_info_manager/src/camera_info_manager.cpp
+++ b/camera_info_manager/src/camera_info_manager.cpp
@@ -85,7 +85,7 @@ CameraInfoManager::CameraInfoManager(ros::NodeHandle nh,
 {
   // register callback for camera calibration service request
   info_service_ = nh_.advertiseService("set_camera_info",
-                                       &CameraInfoManager::setCameraInfo, this);
+                                       &CameraInfoManager::setCameraInfoService, this);
 }
 
 /** Get the current CameraInfo data.
@@ -105,7 +105,7 @@ CameraInfoManager::CameraInfoManager(ros::NodeHandle nh,
  */
 sensor_msgs::CameraInfo CameraInfoManager::getCameraInfo(void)
 {
-  while (true)
+  while (ros::ok())
     {
       std::string cname;
       std::string url;
@@ -553,8 +553,8 @@ CameraInfoManager::saveCalibrationFile(const sensor_msgs::CameraInfo &new_info,
  * @return true if message handled
  */
 bool 
-CameraInfoManager::setCameraInfo(sensor_msgs::SetCameraInfo::Request &req,
-                                 sensor_msgs::SetCameraInfo::Response &rsp)
+CameraInfoManager::setCameraInfoService(sensor_msgs::SetCameraInfo::Request &req,
+                                        sensor_msgs::SetCameraInfo::Response &rsp)
 {
   // copies of class variables needed for saving calibration
   std::string url_copy;
@@ -613,6 +613,24 @@ bool CameraInfoManager::setCameraName(const std::string &cname)
     camera_name_ = cname;
     loaded_cam_info_ = false;
   }
+
+  return true;
+}
+
+/** Set the camera info manually
+ *
+ * @param camera_info new camera calibration data
+ *
+ * @return true if new camera info is set
+ *
+ * @post @c cam_info_ updated, if valid;
+ */
+bool CameraInfoManager::setCameraInfo(const sensor_msgs::CameraInfo &camera_info)
+{
+  boost::mutex::scoped_lock lock(mutex_);
+
+  cam_info_ = camera_info;
+  loaded_cam_info_ = true;
 
   return true;
 }


### PR DESCRIPTION
See https://github.com/ros-perception/image_common/issues/19

TODO before merge:
- [x] Check ABI compatibility
