### PR TITLE
added codes in Constructor of CameraInfoManager to change service name

### DIFF
--- a/camera_info_manager/include/camera_info_manager/camera_info_manager.h
+++ b/camera_info_manager/include/camera_info_manager/camera_info_manager.h
@@ -177,7 +177,8 @@ class CameraInfoManager
 
   CameraInfoManager(ros::NodeHandle nh,
                     const std::string &cname="camera",
-                    const std::string &url="");
+                    const std::string &url="",
+		    const std::string &srvname="set_camera_info");
 
   sensor_msgs::CameraInfo getCameraInfo(void);
   bool isCalibrated(void);

--- a/camera_info_manager/src/camera_info_manager.cpp
+++ b/camera_info_manager/src/camera_info_manager.cpp
@@ -77,14 +77,15 @@ const std::string
  */
 CameraInfoManager::CameraInfoManager(ros::NodeHandle nh,
                                      const std::string &cname,
-                                     const std::string &url):
+                                     const std::string &url,
+				     const std::string &srvname):
   nh_(nh),
   camera_name_(cname),
   url_(url),
   loaded_cam_info_(false)
 {
   // register callback for camera calibration service request
-  info_service_ = nh_.advertiseService("set_camera_info",
+  info_service_ = nh_.advertiseService(srvname,
                                        &CameraInfoManager::setCameraInfoService, this);
 }
 


### PR DESCRIPTION
I  think it is convenient if I can change service name that CameraInfoManager provides.
I'm writing leapmotion-image driver and I want to include two CameraInfoManager in the same code whose service names are left/set_camera_info and right/set_camera_info.
