### PR TITLE
Make function inline to avoid duplicated names when linking statically

### DIFF
--- a/image_transport/src/camera_subscriber.cpp
+++ b/image_transport/src/camera_subscriber.cpp
@@ -38,7 +38,7 @@
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 
-void increment(int* value)
+inline void increment(int* value)
 {
   ++(*value);
 }


### PR DESCRIPTION
Based on https://github.com/ros-perception/image_pipeline/pull/113
