### PR TITLE
Saving the final URL

### DIFF
--- a/camera_info_manager/include/camera_info_manager/camera_info_manager.h
+++ b/camera_info_manager/include/camera_info_manager/camera_info_manager.h
@@ -187,6 +187,7 @@ class CameraInfoManager
   bool setCameraName(const std::string &cname);
   bool setCameraInfo(const sensor_msgs::CameraInfo &camera_info);
   bool validateURL(const std::string &url);
+  std::string getURL(){ return url_;}
 
  private:
 

--- a/camera_info_manager/include/camera_info_manager/camera_info_manager.h
+++ b/camera_info_manager/include/camera_info_manager/camera_info_manager.h
@@ -187,7 +187,7 @@ class CameraInfoManager
   bool setCameraName(const std::string &cname);
   bool setCameraInfo(const sensor_msgs::CameraInfo &camera_info);
   bool validateURL(const std::string &url);
-  std::string getURL(){ return url_;}
+  const std::string& getURL() const { return url_;}
 
  private:
 

--- a/camera_info_manager/src/camera_info_manager.cpp
+++ b/camera_info_manager/src/camera_info_manager.cpp
@@ -281,9 +281,10 @@ bool CameraInfoManager::loadCalibrationFile(const std::string &filename,
         }
       success = true;
       {
-        // lock only while updating cam_info_
+        // lock only while updating cam_info_ and url_
         boost::mutex::scoped_lock lock(mutex_);
         cam_info_ = cam_info;
+        url_ = filename;
       }
     }
   else


### PR DESCRIPTION
This patch allows external users (let's say openni_camera/driver for example :)) to get where the camera info manager loaded the calibration file.
This can be used to publish in the camera_info_url (it's an empty string in openni_camera).

Note : we could make  

``` cpp
default_camera_info_url = "file://${ROS_HOME}/camera_info/${NAME}.yaml";
```

public and use 

``` cpp
std::string CameraInfoManager::resolveURL(const std::string &url,
                                          const std::string &cname)
```
