### PR TITLE
image_transport: fix CameraSubscriber shutdown (circular shared_ptr ref)

### DIFF
--- a/image_transport/src/camera_subscriber.cpp
+++ b/image_transport/src/camera_subscriber.cpp
@@ -118,7 +118,7 @@ CameraSubscriber::CameraSubscriber(ImageTransport& image_it, ros::NodeHandle& in
   impl_->info_sub_.registerCallback(boost::bind(increment, &impl_->info_received_));
   impl_->sync_.registerCallback(boost::bind(increment, &impl_->both_received_));
   impl_->check_synced_timer_ = info_nh.createWallTimer(ros::WallDuration(10.0),
-                                                       boost::bind(&Impl::checkImagesSynchronized, impl_));
+                                                       boost::bind(&Impl::checkImagesSynchronized, impl_.get()));
 }
 
 std::string CameraSubscriber::getTopic() const


### PR DESCRIPTION
CameraSubscriber uses a private boost::shared_ptr to share an impl object
between copied instances. In CameraSubscriber::CameraSubscriber(), it
handed this shared_ptr to boost::bind() and saved the created wall timer
in the impl object, thus creating a circular reference. The impl object
was therefore never freed.

Fix that by passing a plain pointer to boost::bind().
