### PR TITLE
[camera_calibration_parsers] Better error message when calib file can't be written

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -3,7 +3,9 @@ project(camera_calibration_parsers)
 
 find_package(catkin REQUIRED sensor_msgs rosconsole)
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+find_package(Boost REQUIRED COMPONENTS filesystem)
+
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 catkin_package(
   INCLUDE_DIRS include
@@ -37,7 +39,7 @@ add_library(${PROJECT_NAME}
   src/parse_yml.cpp
 )
 
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES} ${Boost_LIBRARIES})
 
 add_dependencies(${PROJECT_NAME} sensor_msgs_gencpp)
 

--- a/camera_calibration_parsers/package.xml
+++ b/camera_calibration_parsers/package.xml
@@ -21,6 +21,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>yaml-cpp</build_depend>
 
+  <run_depend>boost</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>yaml-cpp</run_depend>
 

--- a/camera_calibration_parsers/src/parse_ini.cpp
+++ b/camera_calibration_parsers/src/parse_ini.cpp
@@ -43,6 +43,7 @@
 #include <boost/spirit/include/classic_confix.hpp>
 #include <boost/spirit/include/classic_loops.hpp>
 #include <boost/typeof/typeof.hpp>
+#include <boost/filesystem.hpp>
 #include <iterator>
 #include <fstream>
 
@@ -112,6 +113,11 @@ bool writeCalibrationIni(std::ostream& out, const std::string& camera_name,
 bool writeCalibrationIni(const std::string& file_name, const std::string& camera_name,
                          const sensor_msgs::CameraInfo& cam_info)
 {
+  boost::filesystem::path dir(boost::filesystem::path(file_name).parent_path());
+  if(!boost::filesystem::exists(dir) &&
+     !boost::filesystem::create_directories(dir)){
+    ROS_ERROR("Unable to create directory for camera calibration file [%s]", dir.c_str());
+  }
   std::ofstream out(file_name.c_str());
   if (!out.is_open())
   {

--- a/camera_calibration_parsers/src/parse_yml.cpp
+++ b/camera_calibration_parsers/src/parse_yml.cpp
@@ -34,6 +34,7 @@
 
 #include "camera_calibration_parsers/parse_yml.h"
 #include <sensor_msgs/distortion_models.h>
+#include <boost/filesystem.hpp>
 #include <yaml-cpp/yaml.h>
 #include <fstream>
 #include <ctime>
@@ -140,6 +141,11 @@ bool writeCalibrationYml(std::ostream& out, const std::string& camera_name,
 bool writeCalibrationYml(const std::string& file_name, const std::string& camera_name,
                          const sensor_msgs::CameraInfo& cam_info)
 {
+  boost::filesystem::path dir(boost::filesystem::path(file_name).parent_path());
+  if(!boost::filesystem::exists(dir) &&
+     !boost::filesystem::create_directories(dir)){
+    ROS_ERROR("Unable to create directory for camera calibration file [%s]", dir.c_str());
+  }
   std::ofstream out(file_name.c_str());
   if (!out.is_open())
   {


### PR DESCRIPTION
In [this issue](http://answers.ros.org/question/209058/unable-to-set-camera-info-for-calibration/), I was wondering why the calibration file wasn't opened. I can't test the same situation now so I don't know whether the error was because the file wasn't actually written. Either way, better error upon file creation message helps.

Patch thanks to @k-okada
