### PR TITLE
Remove special OS X flags for camera calibration parsers

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -15,12 +15,7 @@ catkin_package(
 
 find_package(PkgConfig)
 
-if (APPLE)
-  #find yaml cpp for mac os
-  find_library(YAML_CPP_LIBRARIES NAMES yaml-cpp)
-  find_path(YAML_CPP_H_INCLUDE_DIR yaml-cpp/yaml.h )
-  SET(YAML_CPP_INCLUDE_DIR ${YAML_CPP_H_INCLUDE_DIR}/yaml-cpp)
-elseif (ANDROID)
+if (ANDROID)
     find_package(yaml-cpp)
     add_definitions(-DHAVE_NEW_YAMLCPP)
 else()


### PR DESCRIPTION
This is no longer necessary, as the yaml-cpp libraries now get installed in the correct place by default, and now allows us to use 0.3 or 0.5 of yaml-cpp on mac as well. :)

As discussed in/resolves https://github.com/ros-perception/image_common/issues/40
