### PR TITLE
Add python wrapper for readCalibration.

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -1,11 +1,13 @@
 cmake_minimum_required(VERSION 2.8)
 project(camera_calibration_parsers)
 
-find_package(catkin REQUIRED sensor_msgs rosconsole)
+find_package(catkin REQUIRED sensor_msgs rosconsole roscpp roscpp_serialization)
 
-find_package(Boost REQUIRED COMPONENTS filesystem)
+find_package(Boost REQUIRED COMPONENTS filesystem python)
+find_package(PythonLibs 2.7 REQUIRED)
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS})
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+catkin_python_setup()
 
 catkin_package(
   INCLUDE_DIRS include
@@ -14,6 +16,7 @@ catkin_package(
 )
 
 find_package(PkgConfig)
+
 
 if (ANDROID)
     find_package(yaml-cpp)
@@ -34,7 +37,17 @@ add_library(${PROJECT_NAME}
   src/parse_yml.cpp
 )
 
+add_library(${PROJECT_NAME}_wrapper
+  src/parse_wrapper.cpp)
+
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_wrapper ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
+
+# Don't prepend wrapper library name with lib and add to Python libs.
+set_target_properties(${PROJECT_NAME}_wrapper PROPERTIES
+        PREFIX ""
+        LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
+        )
 
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 

--- a/camera_calibration_parsers/include/camera_calibration_parsers/parse_wrapper.h
+++ b/camera_calibration_parsers/include/camera_calibration_parsers/parse_wrapper.h
@@ -1,0 +1,44 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+* 
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+* 
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+* 
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#ifndef CAMERA_CALIBRATION_PARSERS_PARSE_WRAPPER_H
+#define CAMERA_CALIBRATION_PARSERS_PARSE_WRAPPER_H
+
+#include <string>
+#include <boost/python.hpp>
+
+namespace camera_calibration_parsers {
+
+boost::python::tuple readCalibrationWrapper(const std::string& file_name);
+
+} //namespace camera_calibration_parsers
+
+#endif

--- a/camera_calibration_parsers/package.xml
+++ b/camera_calibration_parsers/package.xml
@@ -20,10 +20,14 @@
   <build_depend>rosconsole</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>yaml-cpp</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>roscpp_serialization</build_depend>
 
   <run_depend>boost</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>yaml-cpp</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>roscpp_serialization</run_depend>
 
   <test_depend>rosbash</test_depend>
   <test_depend>rosunit</test_depend>

--- a/camera_calibration_parsers/setup.py
+++ b/camera_calibration_parsers/setup.py
@@ -1,0 +1,11 @@
+# ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['camera_calibration_parsers'],
+    package_dir={'': 'src'})
+
+setup(**setup_args)

--- a/camera_calibration_parsers/src/camera_calibration_parsers/__init__.py
+++ b/camera_calibration_parsers/src/camera_calibration_parsers/__init__.py
@@ -1,0 +1,17 @@
+from camera_calibration_parsers.camera_calibration_parsers_wrapper import __readCalibrationWrapper
+from sensor_msgs.msg import CameraInfo
+
+def readCalibration(file_name):
+    """Read .ini or .yaml calibration file and return (camera name and cameraInfo message).
+    
+    @param file_name: camera calibration file name
+    @type file_name: str
+    @return: (camera name, cameraInfo message) or None on Error
+    @rtype: tuple(str, sensor_msgs.msg.CameraInfo | None
+    """
+    ret, cn, ci = __readCalibrationWrapper(file_name)
+    if not ret:
+        return None
+    c = CameraInfo()
+    c.deserialize(ci)
+    return cn, c

--- a/camera_calibration_parsers/src/parse_wrapper.cpp
+++ b/camera_calibration_parsers/src/parse_wrapper.cpp
@@ -1,0 +1,74 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+* 
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+* 
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+* 
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#include "camera_calibration_parsers/parse.h"
+#include "camera_calibration_parsers/parse_wrapper.h"
+
+#include <boost/python.hpp>
+#include <ros/serialization.h>
+
+namespace camera_calibration_parsers {
+
+/* Write a ROS message into a serialized string.
+ * @from https://github.com/galou/python_bindings_tutorial/blob/master/src/add_two_ints_wrapper.cpp#L27
+*/
+template <typename M>
+std::string to_python(const M& msg)
+{
+  size_t serial_size = ros::serialization::serializationLength(msg);
+  boost::shared_array<uint8_t> buffer(new uint8_t[serial_size]);
+  ros::serialization::OStream stream(buffer.get(), serial_size);
+  ros::serialization::serialize(stream, msg);
+  std::string str_msg;
+  str_msg.reserve(serial_size);
+  for (size_t i = 0; i < serial_size; ++i)
+  {
+    str_msg.push_back(buffer[i]);
+  }
+  return str_msg;
+}
+
+// Wrapper for readCalibration()
+boost::python::tuple readCalibrationWrapper(const std::string& file_name)
+{
+  std::string camera_name;
+  sensor_msgs::CameraInfo camera_info;
+  bool result = readCalibration(file_name, camera_name, camera_info);
+  std::string cam_info = to_python(camera_info);
+  return boost::python::make_tuple(result, camera_name, cam_info);
+}
+
+BOOST_PYTHON_MODULE(camera_calibration_parsers_wrapper)
+{
+    boost::python::def("__readCalibrationWrapper", readCalibrationWrapper, boost::python::args("file_name"), "");
+}
+
+} //namespace camera_calibration_parsers

--- a/camera_calibration_parsers/test/parser.py
+++ b/camera_calibration_parsers/test/parser.py
@@ -35,6 +35,8 @@
 import rosunit
 import subprocess
 import unittest
+import os
+from camera_calibration_parsers import readCalibration
 
 class TestParser(unittest.TestCase):
     def test_ini(self):
@@ -43,6 +45,17 @@ class TestParser(unittest.TestCase):
                 p = subprocess.Popen('rosrun camera_calibration_parsers convert $(rospack find camera_calibration_parsers)/test/%s %s%s' % (files[0], dir, files[1]), shell=True, stderr=subprocess.PIPE)
                 out, err = p.communicate()
                 self.assertEqual(err, '')
+
+    def test_readCalibration(self):
+        script_dir = os.path.dirname(os.path.realpath(__file__))
+        camera_name, camera_info = readCalibration(os.path.join(script_dir, 'calib5.ini'))
+        self.assertEqual(camera_name, 'mono_left')
+        self.assertEqual(camera_info.height, 480)
+        self.assertEqual(camera_info.width, 640)
+        self.assertEqual(camera_info.P[0], 262.927429)
+        
+        camera_name, camera_info = readCalibration(os.path.join(script_dir, 'calib8.ini'))
+        self.assertEqual(camera_info.distortion_model, 'rational_polynomial')
 
 if __name__ == '__main__':
     rosunit.unitrun('camera_calibration_parsers', 'parser', TestParser)


### PR DESCRIPTION
Reads .ini or .yaml calibration file and returns camera name and sensor_msgs/cameraInfo.
Includes test.

```
catkin_make run_tests_camera_calibration_parsers
```
