### PR TITLE
Only link against needed Boost libraries

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -40,8 +40,8 @@ add_library(${PROJECT_NAME}
 add_library(${PROJECT_NAME}_wrapper
   src/parse_wrapper.cpp)
 
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES} ${Boost_LIBRARIES})
-target_link_libraries(${PROJECT_NAME}_wrapper ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY})
+target_link_libraries(${PROJECT_NAME}_wrapper ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_PYTHON_LIBRARY} ${PYTHON_LIBRARIES})
 
 # Don't prepend wrapper library name with lib and add to Python libs.
 set_target_properties(${PROJECT_NAME}_wrapper PROPERTIES


### PR DESCRIPTION
9829b02 introduced a python dependency into find_package(Boost..) which
results in ${Boost_LIBRARIES} containing boost_python and such a
dependency to libpython at link time. With this patch we only link
against the needed libraries.
