### PR TITLE
address gcc6 build error in polled_camera

### DIFF
--- a/polled_camera/CMakeLists.txt
+++ b/polled_camera/CMakeLists.txt
@@ -17,7 +17,7 @@ catkin_package(DEPENDS roscpp sensor_msgs
 
 # create some library and exe
 find_package(catkin REQUIRED image_transport rosconsole roscpp)
-include_directories(SYSTEM ${image_transport_INCLUDE_DIRS})
+include_directories(${image_transport_INCLUDE_DIRS})
 include_directories(include
                     ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}
 )


### PR DESCRIPTION
With gcc6, compiling fails with `stdlib.h: No such file or directory`,
as including '-isystem /usr/include' breaks with gcc6, cf.,
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129

This commit addresses this issue for polled_camera in the same way
it was addressed in the following commits for the image_geometry
package and the tf package:
- https://github.com/ros-perception/vision_opencv/commit/ead421b85eeb750cbf7988657015296ed6789bcf
- https://github.com/ros/geometry/commit/b0d31cc1e9a43b45d216ee7f804e901a5c0f8936

Signed-off-by: Lukas Bulwahn lukas.bulwahn@oss.bmw-carit.de
