### PR TITLE
Return empty CameraInfo when !ros::ok()

### DIFF
--- a/camera_info_manager/src/camera_info_manager.cpp
+++ b/camera_info_manager/src/camera_info_manager.cpp
@@ -128,6 +128,8 @@ sensor_msgs::CameraInfo CameraInfoManager::getCameraInfo(void)
       // attempt load without the lock, it is not recursive
       loadCalibration(url, cname);
     }
+
+  return sensor_msgs::CameraInfo();
 }
 
 /** Get file name corresponding to a @c package: URL.


### PR DESCRIPTION
@vrabaud @mikepurvis

This makes the `header.frame_id` SEGFAULT.

You can use this package to reproduce it: https://github.com/efernandez/test_camera_info

This was impacting this driver: https://github.com/ros-drivers/pointgrey_camera_driver/blob/master/pointgrey_camera_driver/src/nodelet.cpp#L437
