### PR TITLE
Fix CMakeLists of image_transport/tutorial + polled_camera

### DIFF
--- a/image_transport/tutorial/CMakeLists.txt
+++ b/image_transport/tutorial/CMakeLists.txt
@@ -17,12 +17,15 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
 
 # add the publisher example
 add_executable(my_publisher src/my_publisher.cpp)
+add_dependencies(my_publisher ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
 target_link_libraries(my_publisher ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
 # add the subscriber example
 add_executable(my_subscriber src/my_subscriber.cpp)
+add_dependencies(my_subscriber ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
 target_link_libraries(my_subscriber ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
 # add the plugin examples
 add_library(resized_publisher src/manifest.cpp src/resized_publisher.cpp src/resized_subscriber.cpp)
+add_dependencies(resized_publisher ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
 target_link_libraries(resized_publisher ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})

--- a/image_transport/tutorial/CMakeLists.txt
+++ b/image_transport/tutorial/CMakeLists.txt
@@ -13,7 +13,7 @@ catkin_package()
 
 find_package(OpenCV)
 
-include_directories(include ${OpenCV_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
 
 # add the publisher example
 add_executable(my_publisher src/my_publisher.cpp)

--- a/image_transport/tutorial/CMakeLists.txt
+++ b/image_transport/tutorial/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(image_transport_tutorial)
 
-find_package(catkin REQUIRED cv_bridge genmsg image_transport sensor_msgs)
+find_package(catkin REQUIRED COMPONENTS cv_bridge image_transport message_generation sensor_msgs)
 
 # add the resized image message
 add_message_files(DIRECTORY msg
@@ -9,7 +9,7 @@ add_message_files(DIRECTORY msg
 )
 generate_messages(DEPENDENCIES sensor_msgs)
 
-catkin_package()
+catkin_package(CATKIN_DEPENDS cv_bridge image_transport message_runtime sensor_msgs)
 
 find_package(OpenCV)
 
@@ -25,7 +25,19 @@ add_executable(my_subscriber src/my_subscriber.cpp)
 add_dependencies(my_subscriber ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
 target_link_libraries(my_subscriber ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
-# add the plugin examples
+# add the plugin example
 add_library(resized_publisher src/manifest.cpp src/resized_publisher.cpp src/resized_subscriber.cpp)
 add_dependencies(resized_publisher ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
 target_link_libraries(resized_publisher ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
+
+
+# Mark executables and/or libraries for installation
+install(TARGETS my_publisher my_subscriber resized_publisher
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(FILES resized_plugins.xml
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/image_transport/tutorial/package.xml
+++ b/image_transport/tutorial/package.xml
@@ -16,6 +16,7 @@
   <run_depend>image_transport</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>opencv2</run_depend>
+  <run_depend>sensor_msgs</run_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/polled_camera/CMakeLists.txt
+++ b/polled_camera/CMakeLists.txt
@@ -2,29 +2,29 @@ cmake_minimum_required(VERSION 2.8)
 project(polled_camera)
 
 # generate the server
-find_package(catkin REQUIRED message_generation roscpp sensor_msgs std_msgs)
+find_package(catkin REQUIRED COMPONENTS image_transport message_generation roscpp sensor_msgs std_msgs)
 
 add_service_files(DIRECTORY srv FILES GetPolledImage.srv)
 
 generate_messages(DEPENDENCIES sensor_msgs std_msgs)
 
 # define the project
-catkin_package(DEPENDS roscpp sensor_msgs
+catkin_package(CATKIN_DEPENDS image_transport message_runtime roscpp sensor_msgs std_msgs
                INCLUDE_DIRS include
                LIBRARIES ${PROJECT_NAME}
 )
 
 
 # create some library and exe
-find_package(catkin REQUIRED image_transport rosconsole roscpp)
-include_directories(${image_transport_INCLUDE_DIRS})
 include_directories(include
+                    ${catkin_INCLUDE_DIRS} 
                     ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}
 )
 
 add_library(${PROJECT_NAME} src/publication_server.cpp)
-add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencpp)
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+
 install(TARGETS ${PROJECT_NAME}
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
@@ -33,9 +33,11 @@ install(DIRECTORY include/${PROJECT_NAME}/
 )
 
 add_executable(poller src/poller.cpp)
+add_dependencies(poller ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
 target_link_libraries(poller ${PROJECT_NAME}
                              ${catkin_LIBRARIES}
 )
+
 install(TARGETS poller
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/polled_camera/package.xml
+++ b/polled_camera/package.xml
@@ -19,15 +19,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
   <build_depend>image_transport</build_depend>
-  <build_depend>rosconsole</build_depend>
+  <build_depend>message_generation</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
 
   <run_depend>image_transport</run_depend>
-  <run_depend>rosconsole</run_depend>
+  <run_depend>message_runtime</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>


### PR DESCRIPTION
There were many errors in those CMakeLists, including duplicate
catkin_package stanzas etc.

I didn't have time to clean up the other packages
(camera_calibration_parsers, camera_info_manager, image_transport). I
recommend running catkin_lint on those as well.

This PR fixes compilation of image_transport/tutorial on Kinetic.