### PR TITLE
Use Boost_LIBRARIES instead of Boost_PYTHON_LIBRARY

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -45,7 +45,7 @@ add_library(${PROJECT_NAME}_wrapper
   src/parse_wrapper.cpp)
 
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY})
-target_link_libraries(${PROJECT_NAME}_wrapper ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_PYTHON_LIBRARY} ${PYTHON_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_wrapper ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
 
 # Don't prepend wrapper library name with lib and add to Python libs.
 set_target_properties(${PROJECT_NAME}_wrapper PROPERTIES


### PR DESCRIPTION
This was causing issues when building with python3 since then `Boost_PYTHON_LIBRARY` is not set, instead cmake sets `Boost_PYTHON3_LIBRARY`. So instead of adding each library separately, using `Boost_LIBRARIES` seems to be better. For reference, from the cmake docs:
```
Boost_LIBRARIES        - Boost component libraries to be linked
Boost_<C>_LIBRARY      - Libraries to link for component <C>
```