### PR TITLE
Added cv::waitkey(10) for blank popup

### DIFF
--- a/image_transport/tutorial/src/my_subscriber.cpp
+++ b/image_transport/tutorial/src/my_subscriber.cpp
@@ -8,6 +8,7 @@ void imageCallback(const sensor_msgs::ImageConstPtr& msg)
   try
   {
     cv::imshow("view", cv_bridge::toCvShare(msg, "bgr8")->image);
+    cv::waitKey(10);
   }
   catch (cv_bridge::Exception& e)
   {


### PR DESCRIPTION
Without the cv::waitkey(10), it results in a blank popup which crashes/ leads to a black popup. This change corrects that problem.

Tested for ROS Kinetic, Ubuntu 16.04.3. 

Source: Error occurred while using ROS tutorials for at wiki.ros.org 

http://wiki.ros.org/image_transport/Tutorials/PublishingImages