### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/image_transport/tutorial/src/manifest.cpp
+++ b/image_transport/tutorial/src/manifest.cpp
@@ -2,7 +2,6 @@
 #include <image_transport_tutorial/resized_publisher.h>
 #include <image_transport_tutorial/resized_subscriber.h>
 
-PLUGINLIB_REGISTER_CLASS(resized_pub, ResizedPublisher, image_transport::PublisherPlugin)
+PLUGINLIB_EXPORT_CLASS(ResizedPublisher, image_transport::PublisherPlugin)
 
-PLUGINLIB_REGISTER_CLASS(resized_sub, ResizedSubscriber, image_transport::SubscriberPlugin)
-
+PLUGINLIB_EXPORT_CLASS(ResizedSubscriber, image_transport::SubscriberPlugin)


### PR DESCRIPTION
This macro, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)
