### PR TITLE
update include statements to use new pluginlib and class_loader headers

### DIFF
--- a/image_transport/src/image_transport.cpp
+++ b/image_transport/src/image_transport.cpp
@@ -35,7 +35,7 @@
 #include "image_transport/image_transport.h"
 #include "image_transport/publisher_plugin.h"
 #include "image_transport/subscriber_plugin.h"
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/foreach.hpp>
 #include <boost/algorithm/string/erase.hpp>

--- a/image_transport/src/list_transports.cpp
+++ b/image_transport/src/list_transports.cpp
@@ -34,7 +34,7 @@
 
 #include "image_transport/publisher_plugin.h"
 #include "image_transport/subscriber_plugin.h"
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <boost/foreach.hpp>
 #include <boost/algorithm/string/erase.hpp>
 #include <map>

--- a/image_transport/src/manifest.cpp
+++ b/image_transport/src/manifest.cpp
@@ -32,7 +32,7 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "image_transport/raw_publisher.h"
 #include "image_transport/raw_subscriber.h"
 

--- a/image_transport/src/publisher.cpp
+++ b/image_transport/src/publisher.cpp
@@ -34,7 +34,7 @@
 
 #include "image_transport/publisher.h"
 #include "image_transport/publisher_plugin.h"
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <boost/foreach.hpp>
 #include <boost/algorithm/string/erase.hpp>
 

--- a/image_transport/src/republish.cpp
+++ b/image_transport/src/republish.cpp
@@ -34,7 +34,7 @@
 
 #include "image_transport/image_transport.h"
 #include "image_transport/publisher_plugin.h"
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 int main(int argc, char** argv)
 {

--- a/image_transport/src/subscriber.cpp
+++ b/image_transport/src/subscriber.cpp
@@ -35,7 +35,7 @@
 #include "image_transport/subscriber.h"
 #include "image_transport/subscriber_plugin.h"
 #include <ros/names.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <boost/scoped_ptr.hpp>
 
 namespace image_transport {

--- a/image_transport/tutorial/src/manifest.cpp
+++ b/image_transport/tutorial/src/manifest.cpp
@@ -1,4 +1,4 @@
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <image_transport_tutorial/resized_publisher.h>
 #include <image_transport_tutorial/resized_subscriber.h>
 


### PR DESCRIPTION
Disclaimer: This in an automated PR, if it is not relevant on this branch, apologies for the inconveniance, feel free close it.

----

`pluginlib` and `class_loader` headers have been refactored and renamed. The previous headers `.h` have been deprecated in favor of their `.hpp` equivalent. The new headers are available on all active ROS distributions and the deprecated ones will be removed in a future version of ROS (likely ROS-N).

This PR migrates the include statements to use the non-deprecated ones and should compile for any active ROS distribution starting with Indigo
The migration was done by running the scripts [pluginlib_headers_migration.py](https://github.com/ros/pluginlib/blob/6ada92c4665a392339c683682de1d1503658c209/scripts/pluginlib_headers_migration.py) and [class_loader_headers_update.py](https://github.com/ros/class_loader/blob/1515546103de4d987daa8f5519ca43fe6cffbca6/scripts/class_loader_headers_update.py) on this repository.