### PR TITLE
Fix finding Boost Python library after its renaming in Boost 1.67

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -5,7 +5,19 @@ find_package(catkin REQUIRED sensor_msgs rosconsole roscpp roscpp_serialization)
 
 find_package(PythonLibs REQUIRED)
 if(PYTHONLIBS_VERSION_STRING VERSION_LESS 3)
-  find_package(Boost REQUIRED COMPONENTS filesystem python)
+  find_package(Boost QUIET)
+  if(Boost_VERSION LESS 106700)
+    find_package(Boost REQUIRED COMPONENTS filesystem python)
+  else()
+    # The boost_python library has been renamed in Boost 1.67 and the FindBoost.cmake
+    # module requires a Python version suffix:
+    #
+    # References:
+    # - https://www.boost.org/docs/libs/1_67_0/libs/python/doc/html/rn.html
+    # - https://cmake.org/cmake/help/v3.12/module/FindBoost.html
+    #
+    find_package(Boost REQUIRED COMPONENTS filesystem python27)
+  endif()
 else()
   find_package(Boost REQUIRED COMPONENTS filesystem python3)
 endif()


### PR DESCRIPTION
Same issue as in https://github.com/ros-perception/vision_opencv/pull/239.

The boost_python library has been [renamed in Boost 1.67](https://www.boost.org/docs/libs/1_67_0/libs/python/doc/html/rn.html) and the [FindBoost.cmake](https://cmake.org/cmake/help/v3.12/module/FindBoost.html) module requires a Python version suffix.

Currently hard-coding `python27` for Python 2 builds, but I assume that's a reasonable assumption. The alternative would be to extract the major and minor version from `PYTHONLIBS_VERSION_STRING`.