### PR TITLE
Make ROS2 ImageTransport conform to old api

### DIFF
--- a/image_transport/include/image_transport/image_transport.h
+++ b/image_transport/include/image_transport/image_transport.h
@@ -42,48 +42,50 @@
 
 #include <rclcpp/node.hpp>
 
-#include "image_transport/publisher.h"
-#include "image_transport/subscriber.h"
 #include "image_transport/camera_publisher.h"
 #include "image_transport/camera_subscriber.h"
+#include "image_transport/publisher.h"
+#include "image_transport/subscriber.h"
+#include "image_transport/transport_hints.h"
 
-namespace image_transport {
+namespace image_transport
+{
 
 /*!
  * \brief Advertise an image topic, free function version.
  */
 Publisher create_publisher(
-    rclcpp::Node::SharedPtr node,
-    const std::string & base_topic,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+  rclcpp::Node::SharedPtr node,
+  const std::string & base_topic,
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
 
 /**
  * \brief Subscribe to an image topic, free function version.
  */
 Subscriber create_subscription(
-    rclcpp::Node::SharedPtr node,
-    const std::string & base_topic,
-    const Subscriber::Callback& callback,
-    const std::string& transport,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+  rclcpp::Node::SharedPtr node,
+  const std::string & base_topic,
+  const Subscriber::Callback & callback,
+  const std::string & transport,
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
 
 /*!
  * \brief Advertise a camera, free function version.
  */
 CameraPublisher create_camera_publisher(
-    rclcpp::Node::SharedPtr node,
-    const std::string & base_topic,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+  rclcpp::Node::SharedPtr node,
+  const std::string & base_topic,
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
 
 /*!
  * \brief Subscribe to a camera, free function version.
  */
 CameraSubscriber create_camera_subscription(
-    rclcpp::Node::SharedPtr node,
-    const std::string & base_topic,
-    const CameraSubscriber::Callback & callback,
-    const std::string& transport,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+  rclcpp::Node::SharedPtr node,
+  const std::string & base_topic,
+  const CameraSubscriber::Callback & callback,
+  const std::string & transport,
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
 
 std::vector<std::string> getDeclaredTransports();
 std::vector<std::string> getLoadableTransports();
@@ -97,6 +99,10 @@ std::vector<std::string> getLoadableTransports();
 class ImageTransport
 {
 public:
+  using VoidPtr = std::shared_ptr<void>;
+  using ImageConstPtr = sensor_msgs::msg::Image::ConstSharedPtr;
+  using CameraInfoConstPtr = sensor_msgs::msg::CameraInfo::ConstSharedPtr;
+
   explicit ImageTransport(rclcpp::Node::SharedPtr node);
 
   ~ImageTransport();
@@ -104,29 +110,38 @@ public:
   /*!
    * \brief Advertise an image topic, simple version.
    */
-  Publisher advertise(
-    const std::string & base_topic,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+  Publisher advertise(const std::string & base_topic, uint32_t queue_size, bool latch = false);
+
+  /*!
+   * \brief Advertise an image topic with subcriber status callbacks.
+   */
+  /* TODO(ros2) Implement when SubscriberStatusCallback is available
+   * Publisher advertise(const std::string& base_topic, uint32_t queue_size,
+   *                    const SubscriberStatusCallback& connect_cb,
+   *                    const SubscriberStatusCallback& disconnect_cb = SubscriberStatusCallback(),
+   *                    const ros::VoidPtr& tracked_object = ros::VoidPtr(), bool latch = false);
+   */
 
   /**
    * \brief Subscribe to an image topic, version for arbitrary std::function object.
    */
   Subscriber subscribe(
-    const std::string & base_topic,
-    const Subscriber::Callback& callback,
-    const std::string& transport,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+    const std::string & base_topic, uint32_t queue_size,
+    const Subscriber::Callback & callback,
+    const VoidPtr & tracked_object = VoidPtr(),
+    const TransportHints * transport_hints = nullptr);
 
   /**
    * \brief Subscribe to an image topic, version for bare function.
    */
   Subscriber subscribe(
-    const std::string & base_topic,
-    void (*fp)(const sensor_msgs::msg::Image::ConstSharedPtr&),
-    const std::string& transport,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    const std::string & base_topic, uint32_t queue_size,
+    void (*fp)(const ImageConstPtr &),
+    const TransportHints * transport_hints = nullptr)
   {
-    return subscribe(base_topic, Subscriber::Callback(fp), transport, custom_qos);
+    return subscribe(base_topic, queue_size,
+             std::function<void(const ImageConstPtr &)>(fp),
+             VoidPtr(), transport_hints);
   }
 
   /**
@@ -134,13 +149,12 @@ public:
    */
   template<class T>
   Subscriber subscribe(
-    const std::string & base_topic,
-    void (T::*fp)(const sensor_msgs::msg::Image::ConstSharedPtr&),
-    T* obj,
-    const std::string& transport,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    const std::string & base_topic, uint32_t queue_size,
+    void (T::* fp)(const ImageConstPtr &), T * obj,
+    const TransportHints * transport_hints = nullptr)
   {
-    return subscribe(base_topic, std::bind(fp, obj, std::placeholders::_1), transport, custom_qos);
+    return subscribe(base_topic, queue_size, std::bind(fp, obj, std::placeholders::_1),
+             VoidPtr(), transport_hints);
   }
 
   /**
@@ -148,21 +162,34 @@ public:
    */
   template<class T>
   Subscriber subscribe(
-    const std::string & base_topic,
-    void (T::*fp)(const sensor_msgs::msg::Image::ConstSharedPtr&),
-    const std::shared_ptr<T>& obj,
-    const std::string& transport,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    const std::string & base_topic, uint32_t queue_size,
+    void (T::* fp)(const ImageConstPtr &),
+    const std::shared_ptr<T> & obj,
+    const TransportHints * transport_hints = nullptr)
   {
-    return subscribe(base_topic, std::bind(fp, obj, std::placeholders::_1), transport, custom_qos);
+    return subscribe(base_topic, queue_size, std::bind(fp,
+             obj.get(), std::placeholders::_1), obj, transport_hints);
   }
 
   /*!
    * \brief Advertise a synchronized camera raw image + info topic pair, simple version.
    */
   CameraPublisher advertiseCamera(
-    const std::string & base_topic,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+    const std::string & base_topic, uint32_t queue_size,
+    bool latch = false);
+
+  /*!
+   * \brief Advertise a synchronized camera raw image + info topic pair with subscriber status
+   * callbacks.
+   */
+  /* TODO(ros2) Implement when SubscriberStatusCallback is available
+   * CameraPublisher advertiseCamera(const std::string& base_topic, uint32_t queue_size,
+   *                                const SubscriberStatusCallback& image_connect_cb,
+   *                                const SubscriberStatusCallback& image_disconnect_cb = SubscriberStatusCallback(),
+   *                                const ros::SubscriberStatusCallback& info_connect_cb = ros::SubscriberStatusCallback(),
+   *                                const ros::SubscriberStatusCallback& info_disconnect_cb = ros::SubscriberStatusCallback(),
+   *                                const ros::VoidPtr& tracked_object = ros::VoidPtr(), bool latch = false);
+   */
 
   /**
    * \brief Subscribe to a synchronized image & camera info topic pair, version for arbitrary
@@ -172,22 +199,22 @@ public:
    * named "camera_info" in the same namespace as the base image topic.
    */
   CameraSubscriber subscribeCamera(
-    const std::string & base_topic,
-    const CameraSubscriber::Callback& callback,
-    const std::string& transport,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+    const std::string & base_topic, uint32_t queue_size,
+    const CameraSubscriber::Callback & callback,
+    const VoidPtr & tracked_object = VoidPtr(),
+    const TransportHints * transport_hints = nullptr);
 
   /**
    * \brief Subscribe to a synchronized image & camera info topic pair, version for bare function.
    */
-  CameraSubscriber subscribe_camera(
-    const std::string & base_topic,
-    void (*fp)(const sensor_msgs::msg::Image::ConstSharedPtr&,
-               const sensor_msgs::msg::CameraInfo::ConstSharedPtr&),
-    const std::string& transport,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+  CameraSubscriber subscribeCamera(
+    const std::string & base_topic, uint32_t queue_size,
+    void (*fp)(const ImageConstPtr &,
+               const CameraInfoConstPtr &),
+    const TransportHints * transport_hints = nullptr)
   {
-    return subscribeCamera(base_topic, CameraSubscriber::Callback(fp), transport, custom_qos);
+    return subscribeCamera(base_topic, queue_size, CameraSubscriber::Callback(fp), VoidPtr(),
+             transport_hints);
   }
 
   /**
@@ -195,15 +222,15 @@ public:
    * function with bare pointer.
    */
   template<class T>
-  CameraSubscriber subscribe_camera(
-    const std::string & base_topic,
-    void (T::*fp)(const sensor_msgs::msg::Image::ConstSharedPtr&,
-                  const sensor_msgs::msg::CameraInfo::ConstSharedPtr&),
-    T* obj,
-    const std::string& transport,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+  CameraSubscriber subscribeCamera(
+    const std::string & base_topic, uint32_t queue_size,
+    void (T::* fp)(const ImageConstPtr &,
+                   const CameraInfoConstPtr &), T * obj,
+    const TransportHints * transport_hints = nullptr)
   {
-    return subscribe_camera(base_topic, std::bind(fp, obj, std::placeholders::_1), transport, custom_qos);
+    return subscribeCamera(base_topic, queue_size,
+             std::bind(fp, obj, std::placeholders::_1, std::placeholders::_2), VoidPtr(),
+             transport_hints);
   }
 
   /**
@@ -211,16 +238,18 @@ public:
    * function with shared_ptr.
    */
   template<class T>
-  CameraSubscriber subscribe_camera(
-    const std::string & base_topic,
-    void (T::*fp)(const sensor_msgs::msg::Image::ConstSharedPtr&,
-                  const sensor_msgs::msg::CameraInfo::ConstSharedPtr&),
-    const std::shared_ptr<T> obj,
-    const std::string& transport,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+  CameraSubscriber subscribeCamera(
+    const std::string & base_topic, uint32_t queue_size,
+    void (T::* fp)(const ImageConstPtr &,
+                   const CameraInfoConstPtr &),
+    const std::shared_ptr<T> & obj,
+    const TransportHints * transport_hints = nullptr)
   {
-    return subscribe_camera(base_topic, std::bind(fp, obj, std::placeholders::_1), transport, custom_qos);
+    return subscribeCamera(base_topic, queue_size,
+             std::bind(fp, obj.get(), std::placeholders::_1, std::placeholders::_2), obj,
+             transport_hints);
   }
+
 
   /**
    * \brief Returns the names of all transports declared in the system. Declared
@@ -234,6 +263,10 @@ public:
   std::vector<std::string> getLoadableTransports() const;
 
 private:
+
+  std::string getTransportOrDefault(const TransportHints * transport_hints);
+
+
   struct Impl;
   std::unique_ptr<Impl> impl_;
 };

--- a/image_transport/include/image_transport/transport_hints.h
+++ b/image_transport/include/image_transport/transport_hints.h
@@ -35,7 +35,11 @@
 #ifndef IMAGE_TRANSPORT_TRANSPORT_HINTS_H
 #define IMAGE_TRANSPORT_TRANSPORT_HINTS_H
 
+#include <memory>
 #include <string>
+
+
+#include <rclcpp/parameter_client.hpp>
 
 namespace image_transport {
 
@@ -59,15 +63,11 @@ public:
    * Defaults to the local namespace.
    * @param parameter_name The name of the transport parameter
    */
-  // TODO(ros2) change to equivalent ROS2::TransportHints
-  TransportHints(const std::string& default_transport = "raw",
-                 /*const ros::TransportHints& ros_hints = ros::TransportHints(),*/
-                 /*const ros::NodeHandle& parameter_nh = ros::NodeHandle("~"),*/
+  TransportHints(const std::shared_ptr<rclcpp::SyncParametersClient>& parameter_client,
+                 const std::string& default_transport = "raw",
                  const std::string& parameter_name = "image_transport")
-    /*: ros_hints_(ros_hints), parameter_nh_(parameter_nh)*/
   {
-    /*parameter_nh_.param(parameter_name, transport_, default_transport);*/
-    transport_ = default_transport;
+    transport_  = parameter_client->get_parameter<std::string>(parameter_name, default_transport);
   }
 
   const std::string& getTransport() const
@@ -75,24 +75,8 @@ public:
     return transport_;
   }
 
-  /*
-  const ros::TransportHints& getRosHints() const
-  {
-    return ros_hints_;
-  }
-  */
-
-  /*
-  const ros::NodeHandle& getParameterNH() const
-  {
-    return parameter_nh_;
-  }
-  */
-
 private:
   std::string transport_;
-  //ros::TransportHints ros_hints_;
-  //ros::NodeHandle parameter_nh_;
 };
 
 } //namespace image_transport

--- a/image_transport/include/image_transport/transport_hints.h
+++ b/image_transport/include/image_transport/transport_hints.h
@@ -38,8 +38,7 @@
 #include <memory>
 #include <string>
 
-
-#include <rclcpp/parameter_client.hpp>
+#include <rclcpp/node.hpp>
 
 namespace image_transport {
 
@@ -57,17 +56,15 @@ public:
    * in the node's local namespace. For consistency across ROS applications, the
    * name of this parameter should not be changed without good reason.
    *
+   * @param node Node to use when looking up the transport parameter.
    * @param default_transport Preferred transport to use
-   * @param ros_hints Hints to pass through to ROS subscriptions
-   * @param parameter_nh Node handle to use when looking up the transport parameter.
-   * Defaults to the local namespace.
    * @param parameter_name The name of the transport parameter
    */
-  TransportHints(const std::shared_ptr<rclcpp::SyncParametersClient>& parameter_client,
+  TransportHints(const rclcpp::Node::SharedPtr& node,
                  const std::string& default_transport = "raw",
                  const std::string& parameter_name = "image_transport")
   {
-    transport_  = parameter_client->get_parameter<std::string>(parameter_name, default_transport);
+    node->get_parameter_or<std::string>(parameter_name, transport_, default_transport);
   }
 
   const std::string& getTransport() const

--- a/image_transport/src/image_transport.cpp
+++ b/image_transport/src/image_transport.cpp
@@ -128,14 +128,12 @@ std::vector<std::string> getLoadableTransports()
 struct ImageTransport::Impl
 {
   rclcpp::Node::SharedPtr node_;
-  rclcpp::SyncParametersClient::SharedPtr param_client_;
 };
 
 ImageTransport::ImageTransport(rclcpp::Node::SharedPtr node)
 : impl_(std::make_unique<ImageTransport::Impl>())
 {
   impl_->node_ = node;
-  impl_->param_client_ = std::make_shared<rclcpp::SyncParametersClient>(impl_->node_);
 }
 
 ImageTransport::~ImageTransport() = default;
@@ -200,7 +198,7 @@ std::string ImageTransport::getTransportOrDefault(const TransportHints * transpo
 {
   std::string ret;
   if (nullptr == transport_hints) {
-    TransportHints th(impl_->param_client_);
+    TransportHints th(impl_->node_);
     ret = th.getTransport();
   } else {
     ret = transport_hints->getTransport();

--- a/image_transport/src/image_transport.cpp
+++ b/image_transport/src/image_transport.cpp
@@ -45,18 +45,19 @@
 namespace image_transport
 {
 
-struct Impl {
+struct Impl
+{
   PubLoaderPtr pub_loader_;
   SubLoaderPtr sub_loader_;
 
-  Impl():
-    pub_loader_(std::make_shared<PubLoader>("image_transport", "image_transport::PublisherPlugin")),
+  Impl()
+  : pub_loader_(std::make_shared<PubLoader>("image_transport", "image_transport::PublisherPlugin")),
     sub_loader_(std::make_shared<SubLoader>("image_transport", "image_transport::SubscriberPlugin"))
   {
   }
 };
 
-static Impl* kImpl = new Impl();
+static Impl * kImpl = new Impl();
 
 Publisher create_publisher(
   rclcpp::Node::SharedPtr node,
@@ -70,7 +71,7 @@ Subscriber create_subscription(
   rclcpp::Node::SharedPtr node,
   const std::string & base_topic,
   const Subscriber::Callback & callback,
-  const std::string& transport,
+  const std::string & transport,
   rmw_qos_profile_t custom_qos)
 {
   return Subscriber(node, base_topic, callback, kImpl->sub_loader_, transport, custom_qos);
@@ -88,7 +89,7 @@ CameraSubscriber create_camera_subscription(
   rclcpp::Node::SharedPtr node,
   const std::string & base_topic,
   const CameraSubscriber::Callback & callback,
-  const std::string& transport,
+  const std::string & transport,
   rmw_qos_profile_t custom_qos)
 {
   return CameraSubscriber(node, base_topic, callback, transport, custom_qos);
@@ -127,47 +128,62 @@ std::vector<std::string> getLoadableTransports()
 struct ImageTransport::Impl
 {
   rclcpp::Node::SharedPtr node_;
+  rclcpp::SyncParametersClient::SharedPtr param_client_;
 };
 
-
-ImageTransport::ImageTransport(rclcpp::Node::SharedPtr node):
-  impl_(std::make_unique<ImageTransport::Impl>())
+ImageTransport::ImageTransport(rclcpp::Node::SharedPtr node)
+: impl_(std::make_unique<ImageTransport::Impl>())
 {
   impl_->node_ = node;
+  impl_->param_client_ = std::make_shared<rclcpp::SyncParametersClient>(impl_->node_);
 }
 
 ImageTransport::~ImageTransport() = default;
 
-Publisher ImageTransport::advertise(
-  const std::string& base_topic,
-  rmw_qos_profile_t custom_qos)
+Publisher ImageTransport::advertise(const std::string & base_topic, uint32_t queue_size, bool latch)
 {
+  // TODO(ros2) implement when resolved: https://github.com/ros2/ros2/issues/464
+  (void) latch;
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
+  custom_qos.depth = queue_size;
   return create_publisher(impl_->node_, base_topic, custom_qos);
 }
 
 Subscriber ImageTransport::subscribe(
-  const std::string & base_topic,
-  const Subscriber::Callback& callback,
-  const std::string& transport,
-  rmw_qos_profile_t custom_qos)
+  const std::string & base_topic, uint32_t queue_size,
+  const Subscriber::Callback & callback,
+  const VoidPtr & tracked_object,
+  const TransportHints * transport_hints)
 {
-  return create_subscription(impl_->node_, base_topic, callback, transport, custom_qos);
+  (void) tracked_object;
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
+  custom_qos.depth = queue_size;
+  return create_subscription(impl_->node_, base_topic, callback,
+           getTransportOrDefault(transport_hints), custom_qos);
 }
 
 CameraPublisher ImageTransport::advertiseCamera(
-  const std::string & base_topic,
-  rmw_qos_profile_t custom_qos)
+  const std::string & base_topic, uint32_t queue_size,
+  bool latch)
 {
+  // TODO(ros2) implement when resolved: https://github.com/ros2/ros2/issues/464
+  (void) latch;
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
+  custom_qos.depth = queue_size;
   return create_camera_publisher(impl_->node_, base_topic, custom_qos);
 }
 
 CameraSubscriber ImageTransport::subscribeCamera(
-    const std::string & base_topic,
-    const CameraSubscriber::Callback& callback,
-    const std::string& transport,
-    rmw_qos_profile_t custom_qos)
+  const std::string & base_topic, uint32_t queue_size,
+  const CameraSubscriber::Callback & callback,
+  const VoidPtr & tracked_object,
+  const TransportHints * transport_hints)
 {
-  return  create_camera_subscription(impl_->node_, base_topic, callback, transport, custom_qos);
+  (void) tracked_object;
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
+  custom_qos.depth = queue_size;
+  return create_camera_subscription(impl_->node_, base_topic, callback,
+           getTransportOrDefault(transport_hints), custom_qos);
 }
 
 std::vector<std::string> ImageTransport::getDeclaredTransports() const
@@ -178,6 +194,18 @@ std::vector<std::string> ImageTransport::getDeclaredTransports() const
 std::vector<std::string> ImageTransport::getLoadableTransports() const
 {
   return image_transport::getLoadableTransports();
+}
+
+std::string ImageTransport::getTransportOrDefault(const TransportHints * transport_hints)
+{
+  std::string ret;
+  if (nullptr == transport_hints) {
+    TransportHints th(impl_->param_client_);
+    ret = th.getTransport();
+  } else {
+    ret = transport_hints->getTransport();
+  }
+  return ret;
 }
 
 } //namespace image_transport

--- a/image_transport/test/test_publisher.cpp
+++ b/image_transport/test/test_publisher.cpp
@@ -24,7 +24,7 @@ TEST_F(TestPublisher, Publisher) {
 
 TEST_F(TestPublisher, ImageTransportPublisher) {
   image_transport::ImageTransport it(node_);
-  auto pub = it.advertise("camera/image");
+  auto pub = it.advertise("camera/image", 1);
 }
 
 TEST_F(TestPublisher, CameraPublisher) {
@@ -33,7 +33,7 @@ TEST_F(TestPublisher, CameraPublisher) {
 
 TEST_F(TestPublisher, ImageTransportCameraPublisher) {
   image_transport::ImageTransport it(node_);
-  //auto pub = it.advertise_camera("camera/image");
+  auto pub = it.advertiseCamera("camera/image", 1);
 }
 
 


### PR DESCRIPTION
I have restored the old API to the ImageTransport object.

In doing so, I have also removed the ROS2 style API (rmw_custom_qos), as those are already accessible through the free functions, and seemed to be cluttering up the API.

If folks think it's a good idea, I can add the ROS2-style API back in.