### PR TITLE
force camera_calibration_parsers_wrapper to use extension .so on mac

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(${PROJECT_NAME}_wrapper ${PROJECT_NAME} ${catkin_LIBRARIES
 set_target_properties(${PROJECT_NAME}_wrapper PROPERTIES
         PREFIX ""
         LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
+        SUFFIX ".so"
         )
 
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})


### PR DESCRIPTION
See https://github.com/ros-perception/image_common/issues/91