### PR TITLE
[ROS2] corrections to remapping for raw images

### DIFF
--- a/image_transport/CMakeLists.txt
+++ b/image_transport/CMakeLists.txt
@@ -112,6 +112,11 @@ if(BUILD_TESTING)
     target_link_libraries(${PROJECT_NAME}-message_passing ${PROJECT_NAME})
   endif()
 
+  ament_add_gtest(${PROJECT_NAME}-remapping test/test_remapping.cpp)
+  if(TARGET ${PROJECT_NAME}-remapping)
+    target_link_libraries(${PROJECT_NAME}-remapping ${PROJECT_NAME})
+  endif()
+
   ament_add_gtest(${PROJECT_NAME}-single_subscriber_publisher test/test_single_subscriber_publisher.cpp)
   if(TARGET ${PROJECT_NAME}-single_subscriber_publisher)
     target_link_libraries(${PROJECT_NAME}-single_subscriber_publisher ${PROJECT_NAME})

--- a/image_transport/include/image_transport/raw_publisher.h
+++ b/image_transport/include/image_transport/raw_publisher.h
@@ -61,6 +61,11 @@ protected:
   {
     publish_fn(message);
   }
+
+  virtual std::string getTopicToAdvertise(const std::string& base_topic) const
+  {
+    return base_topic;
+  }
 };
 
 } //namespace image_transport

--- a/image_transport/include/image_transport/raw_subscriber.h
+++ b/image_transport/include/image_transport/raw_subscriber.h
@@ -61,6 +61,11 @@ protected:
   {
     user_cb(message);
   }
+
+  virtual std::string getTopicToSubscribe(const std::string& base_topic) const
+  {
+    return base_topic;
+  }
 };
 
 } //namespace image_transport

--- a/image_transport/test/test_remapping.cpp
+++ b/image_transport/test/test_remapping.cpp
@@ -1,9 +1,12 @@
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <string>
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
+#include "utils.hpp"
 
 #include "image_transport/image_transport.h"
 
@@ -13,12 +16,15 @@ protected:
   void SetUp()
   {
     auto context = rclcpp::contexts::default_context::get_global_default_context();
+
     std::vector<std::string> arguments;
     arguments.push_back("old_topic:=new_topic");
     std::vector<rclcpp::Parameter> initial_parameters;
 
-    node_ = rclcpp::Node::make_shared(
-      "node_name",
+    node_ = rclcpp::Node::make_shared("node", "namespace");
+
+    node_remap_ = rclcpp::Node::make_shared(
+      "node_remap",
       "namespace",
       context,
       arguments,
@@ -27,26 +33,53 @@ protected:
   }
 
   rclcpp::Node::SharedPtr node_;
+  rclcpp::Node::SharedPtr node_remap_;
 };
 
 TEST_F(TestPublisher, Publisher) {
+  const size_t max_retries = 3;
+  const size_t max_loops = 200;
+  const std::chrono::milliseconds sleep_per_loop = std::chrono::milliseconds(10);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  auto image = std::make_shared<sensor_msgs::msg::Image>();
+
   // Subscribe
   bool received{false};
-  // FIXME: this should be `new_topic`
-  auto sub = image_transport::create_subscription(node_, "old_topic",
+  auto sub = image_transport::create_subscription(node_remap_, "old_topic",
     [&received](const sensor_msgs::msg::Image::ConstSharedPtr & msg) {
       (void)msg;
       received = true;
     }, "raw");
 
   // Publish
-  auto pub = image_transport::create_publisher(node_, "old_topic");
-  auto image = std::make_shared<sensor_msgs::msg::Image>();
-  pub.publish(image);
+  auto pub = image_transport::create_publisher(node_, "new_topic");
 
-  // Spin
-  rclcpp::executors::SingleThreadedExecutor executor;
+  ASSERT_EQ("/namespace/new_topic", sub.getTopic());
+  test_rclcpp::wait_for_subscriber(node_remap_, sub.getTopic());
+
+  ASSERT_FALSE(received);
+  ASSERT_EQ(1u, pub.getNumSubscribers());
+  ASSERT_EQ(1u, sub.getNumPublishers());
+
   executor.spin_node_some(node_);
+  executor.spin_node_some(node_remap_);
+
+  size_t retry = 0;
+  while(retry < max_retries && !received) {
+    // generate random image and publish it
+    pub.publish(image);
+
+    executor.spin_node_some(node_);
+    executor.spin_node_some(node_remap_);
+
+    size_t loop = 0;
+    while ((!received) && (loop++ < max_loops)) {
+      std::this_thread::sleep_for(sleep_per_loop);
+      executor.spin_node_some(node_);
+      executor.spin_node_some(node_remap_);
+    }
+  }
 
   EXPECT_TRUE(received);
 }

--- a/image_transport/test/test_remapping.cpp
+++ b/image_transport/test/test_remapping.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "image_transport/image_transport.h"
+
+class TestPublisher : public ::testing::Test
+{
+protected:
+  void SetUp()
+  {
+    auto context = rclcpp::contexts::default_context::get_global_default_context();
+    std::vector<std::string> arguments;
+    arguments.push_back("old_topic:=new_topic");
+    std::vector<rclcpp::Parameter> initial_parameters;
+
+    node_ = rclcpp::Node::make_shared(
+      "node_name",
+      "namespace",
+      context,
+      arguments,
+      initial_parameters
+    );
+  }
+
+  rclcpp::Node::SharedPtr node_;
+};
+
+TEST_F(TestPublisher, Publisher) {
+  // Subscribe
+  bool received{false};
+  // FIXME: this should be `new_topic`
+  auto sub = image_transport::create_subscription(node_, "old_topic",
+    [&received](const sensor_msgs::msg::Image::ConstSharedPtr & msg) {
+      (void)msg;
+      received = true;
+    }, "raw");
+
+  // Publish
+  auto pub = image_transport::create_publisher(node_, "old_topic");
+  auto image = std::make_shared<sensor_msgs::msg::Image>();
+  pub.publish(image);
+
+  // Spin
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.spin_node_some(node_);
+
+  EXPECT_TRUE(received);
+}
+
+int main(int argc, char** argv) {
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}


### PR DESCRIPTION
Addresses #93 and #96.

For #96, the issue is that we were incorrectly appending `/raw` for the `raw_image_transport`.  This could be fixed using an already-existing virtual function that got left out in the port at some point.

For #93, there isn't a direct fix, because there is currently missing wildcard remapping support in ROS2.  For the `raw_image_transport` the standard remapping rules will now work, that is:

`old_topic:=new_topic` will yield a result like `/namespace/old_topic => /namespace/new_topic`

For the other image transports (like `compressed` or `theora`), additional remapping rules will be required until wildcard support is implemented, eg:

`old_topic:=new_topic old_topic/compressed:=new_topic/compressed` will yield  `/namespace/old_topic => /namespace/new_topic` and `/namespace/old_topic/compressed => /namespace/new_topic/compressed` 

When ros2/rcl#232 and ros2/rcl#233 are implemented, then this can be done in a single remapping rule, such as `**/old_topic/**:=\1/new_topic/\2`

