### PR TITLE
Fixing conversion in CameraInfo subscriber

### DIFF
--- a/image_transport/src/camera_subscriber.cpp
+++ b/image_transport/src/camera_subscriber.cpp
@@ -123,7 +123,7 @@ CameraSubscriber::CameraSubscriber(
   std::string info_topic = getCameraInfoTopic(image_topic);
 
   impl_->image_sub_.subscribe(node, image_topic, transport, custom_qos);
-  impl_->info_sub_.subscribe(node, info_topic, custom_qos);
+  impl_->info_sub_.subscribe(node.get(), info_topic, custom_qos);
 
   impl_->sync_.connectInput(impl_->image_sub_, impl_->info_sub_);
   impl_->sync_.registerCallback(std::bind(callback, std::placeholders::_1, std::placeholders::_2));


### PR DESCRIPTION
Fixing this issue:

```
/home/erle/ros2_bouncy_hrim/src/image_common/image_transport/src/camera_subscriber.cpp: In constructor ‘image_transport::CameraSubscriber::CameraSubscriber(rclcpp::Node::SharedPtr, const string&, const Callback&, const string&, rmw_qos_profile_t)’:
/home/erle/ros2_bouncy_hrim/src/image_common/image_transport/src/camera_subscriber.cpp:126:58: error: no matching function for call to ‘message_filters::Subscriber<sensor_msgs::msg::CameraInfo_<std::allocator<void> > >::subscribe(rclcpp::Node::SharedPtr&, std::__cxx11::string&, rmw_qos_profile_t&)’
   impl_->info_sub_.subscribe(node, info_topic, custom_qos);
                                                          ^
In file included from /home/erle/ros2_bouncy_hrim/src/image_common/image_transport/src/camera_subscriber.cpp:38:0:
/home/erle/ros2_bouncy_hrim/install/include/message_filters/subscriber.h:139:8: note: candidate: void message_filters::Subscriber<M>::subscribe(rclcpp::Node*, const string&, rmw_qos_profile_t) [with M = sensor_msgs::msg::CameraInfo_<std::allocator<void> >; std::__cxx11::string = std::__cxx11::basic_string<char>; rmw_qos_profile_t = rmw_qos_profile_t]
   void subscribe(rclcpp::Node* nh, const std::string& topic, const rmw_qos_prof
        ^
/home/erle/ros2_bouncy_hrim/install/include/message_filters/subscriber.h:139:8: note:   no known conversion for argument 1 from ‘rclcpp::Node::SharedPtr {aka std::shared_ptr<rclcpp::Node>}’ to ‘rclcpp::Node*
```