### PR TITLE
update RCUTILS_SET_ERROR_MSG as API changes

### DIFF
--- a/image_transport/src/camera_common.cpp
+++ b/image_transport/src/camera_common.cpp
@@ -49,8 +49,8 @@ std::string getCameraInfoTopic(const std::string & base_topic)
   rcutils_string_array_t tokens;
 
   if (rcutils_split(base_topic.c_str(), '/', allocator, &tokens) != RCUTILS_RET_OK) {
-    RCUTILS_SET_ERROR_MSG(rcutils_get_error_string_safe(), allocator)
-    RCUTILS_LOG_ERROR("%s\n", rcutils_get_error_string_safe());
+    RCUTILS_SET_ERROR_MSG(rcutils_get_error_string().str);
+    RCUTILS_LOG_ERROR("%s\n", rcutils_get_error_string().str);
   } else {
     if (tokens.size > 0) {
       for(size_t ii = 0; ii < tokens.size - 1; ++ii) {


### PR DESCRIPTION
macro "RCUTILS_SET_ERROR_MSG" (from ros2/rcutils/include/rcutils/error_handling.h) use 1 argument instead of 2 arguments.

fix the issue: https://github.com/ros-perception/image_common/issues/101

Signed-off-by: Chris Ye <chris.ye@intel.com>