### PR TITLE
Pointer api updates

### DIFF
--- a/image_transport/include/image_transport/camera_publisher.h
+++ b/image_transport/include/image_transport/camera_publisher.h
@@ -43,7 +43,8 @@
 
 #include "image_transport/single_subscriber_publisher.h"
 
-namespace image_transport {
+namespace image_transport
+{
 
 class ImageTransport;
 
@@ -68,9 +69,10 @@ public:
   CameraPublisher() = default;
 
 
-  CameraPublisher(rclcpp::Node::SharedPtr node,
-                  const std::string& base_topic,
-                  rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+  CameraPublisher(
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
 
   //TODO(ros2) Restore support for SubscriberStatusCallbacks when available.
 
@@ -95,13 +97,16 @@ public:
   /*!
    * \brief Publish an (image, info) pair on the topics associated with this CameraPublisher.
    */
-  void publish(const sensor_msgs::msg::Image& image, const sensor_msgs::msg::CameraInfo& info) const;
+  void publish(
+    const sensor_msgs::msg::Image & image,
+    const sensor_msgs::msg::CameraInfo & info) const;
 
   /*!
    * \brief Publish an (image, info) pair on the topics associated with this CameraPublisher.
    */
-  void publish(const sensor_msgs::msg::Image::ConstSharedPtr& image,
-               const sensor_msgs::msg::CameraInfo::ConstSharedPtr& info) const;
+  void publish(
+    const sensor_msgs::msg::Image::ConstSharedPtr & image,
+    const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info) const;
 
   /*!
    * \brief Publish an (image, info) pair with given timestamp on the topics associated with
@@ -110,17 +115,19 @@ public:
    * Convenience version, which sets the timestamps of both image and info to stamp before
    * publishing.
    */
-  void publish(sensor_msgs::msg::Image& image, sensor_msgs::msg::CameraInfo& info, rclcpp::Time stamp) const;
+  void publish(
+    sensor_msgs::msg::Image & image, sensor_msgs::msg::CameraInfo & info,
+    rclcpp::Time stamp) const;
 
   /*!
    * \brief Shutdown the advertisements associated with this Publisher.
    */
   void shutdown();
 
-  operator void*() const;
-  bool operator< (const CameraPublisher& rhs) const { return impl_ <  rhs.impl_; }
-  bool operator!=(const CameraPublisher& rhs) const { return impl_ != rhs.impl_; }
-  bool operator==(const CameraPublisher& rhs) const { return impl_ == rhs.impl_; }
+  operator void *() const;
+  bool operator<(const CameraPublisher & rhs) const {return impl_ < rhs.impl_;}
+  bool operator!=(const CameraPublisher & rhs) const {return impl_ != rhs.impl_;}
+  bool operator==(const CameraPublisher & rhs) const {return impl_ == rhs.impl_;}
 
 private:
   struct Impl;

--- a/image_transport/include/image_transport/camera_subscriber.h
+++ b/image_transport/include/image_transport/camera_subscriber.h
@@ -69,7 +69,7 @@ public:
 
   CameraSubscriber() = default;
 
-  CameraSubscriber(rclcpp::Node::SharedPtr node,
+  CameraSubscriber(rclcpp::Node * node,
                    const std::string& base_topic,
                    const Callback& callback,
                    const std::string& transport,

--- a/image_transport/include/image_transport/image_transport.h
+++ b/image_transport/include/image_transport/image_transport.h
@@ -55,7 +55,7 @@ namespace image_transport
  * \brief Advertise an image topic, free function version.
  */
 Publisher create_publisher(
-  rclcpp::Node::SharedPtr node,
+  rclcpp::Node* node,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
 
@@ -63,7 +63,7 @@ Publisher create_publisher(
  * \brief Subscribe to an image topic, free function version.
  */
 Subscriber create_subscription(
-  rclcpp::Node::SharedPtr node,
+  rclcpp::Node* node,
   const std::string & base_topic,
   const Subscriber::Callback & callback,
   const std::string & transport,
@@ -73,7 +73,7 @@ Subscriber create_subscription(
  * \brief Advertise a camera, free function version.
  */
 CameraPublisher create_camera_publisher(
-  rclcpp::Node::SharedPtr node,
+  rclcpp::Node* node,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
 
@@ -81,7 +81,7 @@ CameraPublisher create_camera_publisher(
  * \brief Subscribe to a camera, free function version.
  */
 CameraSubscriber create_camera_subscription(
-  rclcpp::Node::SharedPtr node,
+  rclcpp::Node* node,
   const std::string & base_topic,
   const CameraSubscriber::Callback & callback,
   const std::string & transport,

--- a/image_transport/include/image_transport/publisher.h
+++ b/image_transport/include/image_transport/publisher.h
@@ -72,7 +72,7 @@ public:
   Publisher() = default;
 
   Publisher(
-    rclcpp::Node::SharedPtr nh,
+    rclcpp::Node * nh,
     const std::string & base_topic,
     PubLoaderPtr loader,
     rmw_qos_profile_t custom_qos);

--- a/image_transport/include/image_transport/publisher_plugin.h
+++ b/image_transport/include/image_transport/publisher_plugin.h
@@ -50,8 +50,8 @@ class PublisherPlugin
 {
 public:
   PublisherPlugin() = default;
-  PublisherPlugin(const PublisherPlugin&) = delete;
-  PublisherPlugin& operator=( const PublisherPlugin& ) = delete;
+  PublisherPlugin(const PublisherPlugin &) = delete;
+  PublisherPlugin & operator=(const PublisherPlugin &) = delete;
 
   virtual ~PublisherPlugin() {}
 
@@ -65,7 +65,7 @@ public:
    * \brief Advertise a topic, simple version.
    */
   void advertise(
-    rclcpp::Node::SharedPtr & nh,
+    rclcpp::Node * nh,
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
   {
@@ -86,12 +86,12 @@ public:
   /**
    * \brief Publish an image using the transport associated with this PublisherPlugin.
    */
-  virtual void publish(const sensor_msgs::msg::Image& message) const = 0;
+  virtual void publish(const sensor_msgs::msg::Image & message) const = 0;
 
   /**
    * \brief Publish an image using the transport associated with this PublisherPlugin.
    */
-  virtual void publish(const sensor_msgs::msg::Image::ConstSharedPtr& message) const
+  virtual void publish(const sensor_msgs::msg::Image::ConstSharedPtr & message) const
   {
     publish(*message);
   }
@@ -103,7 +103,7 @@ public:
    * @param message an image message to use information from (but not data)
    * @param data a pointer to the image data to use to fill the Image message
    */
-  virtual void publish(const sensor_msgs::msg::Image& message, const uint8_t* data) const
+  virtual void publish(const sensor_msgs::msg::Image & message, const uint8_t * data) const
   {
     sensor_msgs::msg::Image msg;
     msg.header = message.header;
@@ -135,7 +135,9 @@ protected:
   /**
    * \brief Advertise a topic. Must be implemented by the subclass.
    */
-  virtual void advertiseImpl(rclcpp::Node::SharedPtr nh, const std::string& base_topic, rmw_qos_profile_t custom_qos) = 0;
+  virtual void advertiseImpl(
+    rclcpp::Node * nh, const std::string & base_topic,
+    rmw_qos_profile_t custom_qos) = 0;
 };
 
 } //namespace image_transport

--- a/image_transport/include/image_transport/simple_subscriber_plugin.h
+++ b/image_transport/include/image_transport/simple_subscriber_plugin.h
@@ -109,7 +109,7 @@ protected:
   }
 
   virtual void subscribeImpl(
-    rclcpp::Node::SharedPtr node,
+    rclcpp::Node * node,
     const std::string & base_topic,
     const Callback & callback,
     rmw_qos_profile_t custom_qos)

--- a/image_transport/include/image_transport/subscriber.h
+++ b/image_transport/include/image_transport/subscriber.h
@@ -62,16 +62,16 @@ namespace image_transport
 class Subscriber
 {
 public:
-  typedef std::function<void(const sensor_msgs::msg::Image::ConstSharedPtr&)> Callback;
+  typedef std::function<void (const sensor_msgs::msg::Image::ConstSharedPtr &)> Callback;
 
   Subscriber() = default;
 
   Subscriber(
-    rclcpp::Node::SharedPtr node,
+    rclcpp::Node * node,
     const std::string & base_topic,
-    const Callback& callback,
+    const Callback & callback,
     SubLoaderPtr loader,
-    const std::string& transport,
+    const std::string & transport,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
 
   /**
@@ -103,7 +103,6 @@ public:
   bool operator==(const Subscriber & rhs) const {return impl_ == rhs.impl_;}
 
 private:
-
   struct Impl;
   std::shared_ptr<Impl> impl_;
 };

--- a/image_transport/include/image_transport/subscriber_filter.h
+++ b/image_transport/include/image_transport/subscriber_filter.h
@@ -38,7 +38,8 @@
 #include <message_filters/simple_filter.h>
 #include "image_transport/image_transport.h"
 
-namespace image_transport {
+namespace image_transport
+{
 
 /**
  * \brief Image subscription filter.
@@ -72,7 +73,9 @@ public:
    * \param queue_size The subscription queue size
    * \param transport The transport hint to pass along
    */
-  SubscriberFilter(rclcpp::Node::SharedPtr node, const std::string& base_topic, const std::string& transport)
+  SubscriberFilter(
+    rclcpp::Node * node, const std::string & base_topic,
+    const std::string & transport)
   {
     subscribe(node, base_topic, transport);
   }
@@ -98,13 +101,15 @@ public:
    * \param base_topic The topic to subscribe to.
    */
   void subscribe(
-      rclcpp::Node::SharedPtr node,
-      const std::string& base_topic,
-      const std::string& transport,
-      rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    const std::string & transport,
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
   {
     unsubscribe();
-    sub_ = image_transport::create_subscription(node, base_topic, std::bind(&SubscriberFilter::cb, this, std::placeholders::_1), transport, custom_qos);
+    sub_ =
+      image_transport::create_subscription(node, base_topic,
+        std::bind(&SubscriberFilter::cb, this, std::placeholders::_1), transport, custom_qos);
   }
 
   /**
@@ -139,14 +144,13 @@ public:
   /**
    * \brief Returns the internal image_transport::Subscriber object.
    */
-  const Subscriber& getSubscriber() const
+  const Subscriber & getSubscriber() const
   {
     return sub_;
   }
 
 private:
-
-  void cb(const sensor_msgs::msg::Image::ConstSharedPtr& m)
+  void cb(const sensor_msgs::msg::Image::ConstSharedPtr & m)
   {
     signalMessage(m);
   }

--- a/image_transport/include/image_transport/subscriber_plugin.h
+++ b/image_transport/include/image_transport/subscriber_plugin.h
@@ -49,12 +49,12 @@ class SubscriberPlugin
 {
 public:
   SubscriberPlugin() = default;
-  SubscriberPlugin(const SubscriberPlugin&) = delete;
-  SubscriberPlugin& operator=( const SubscriberPlugin& ) = delete;
+  SubscriberPlugin(const SubscriberPlugin &) = delete;
+  SubscriberPlugin & operator=(const SubscriberPlugin &) = delete;
 
   virtual ~SubscriberPlugin() {}
 
-  typedef std::function<void(const sensor_msgs::msg::Image::ConstSharedPtr&)> Callback;
+  typedef std::function<void (const sensor_msgs::msg::Image::ConstSharedPtr &)> Callback;
 
   /**
    * \brief Get a string identifier for the transport provided by
@@ -65,9 +65,10 @@ public:
   /**
    * \brief Subscribe to an image topic, version for arbitrary std::function object.
    */
-  void subscribe(rclcpp::Node::SharedPtr node, const std::string& base_topic,
-                 const Callback& callback,
-                 rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+  void subscribe(
+    rclcpp::Node * node, const std::string & base_topic,
+    const Callback & callback,
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
   {
     return subscribeImpl(node, base_topic, callback, custom_qos);
   }
@@ -75,38 +76,41 @@ public:
   /**
    * \brief Subscribe to an image topic, version for bare function.
    */
-  void subscribe(rclcpp::Node::SharedPtr node, const std::string & base_topic,
-                 void (*fp)(const sensor_msgs::msg::Image::ConstSharedPtr &),
-                 rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+  void subscribe(
+    rclcpp::Node * node, const std::string & base_topic,
+    void (*fp)(const sensor_msgs::msg::Image::ConstSharedPtr &),
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
   {
     return subscribe(node, base_topic,
-                     std::function<void(const sensor_msgs::msg::Image::ConstSharedPtr&)>(fp),
-                     custom_qos);
+             std::function<void(const sensor_msgs::msg::Image::ConstSharedPtr &)>(fp),
+             custom_qos);
   }
 
   /**
    * \brief Subscribe to an image topic, version for class member function with bare pointer.
    */
   template<class T>
-  void subscribe(rclcpp::Node::SharedPtr node, const std::string & base_topic,
-                 void (T::* fp)(const sensor_msgs::msg::Image::ConstSharedPtr &), T * obj,
-                 rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+  void subscribe(
+    rclcpp::Node * node, const std::string & base_topic,
+    void (T::* fp)(const sensor_msgs::msg::Image::ConstSharedPtr &), T * obj,
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
   {
     return subscribe(node, base_topic,
-        std::bind(fp, obj, std::placeholders::_1), custom_qos);
+             std::bind(fp, obj, std::placeholders::_1), custom_qos);
   }
 
   /**
    * \brief Subscribe to an image topic, version for class member function with shared_ptr.
    */
   template<class T>
-  void subscribe(rclcpp::Node::SharedPtr node, const std::string & base_topic,
-                 void (T::* fp)(const sensor_msgs::msg::Image::ConstSharedPtr &),
-                 std::shared_ptr<T>& obj,
-                 rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+  void subscribe(
+    rclcpp::Node * node, const std::string & base_topic,
+    void (T::* fp)(const sensor_msgs::msg::Image::ConstSharedPtr &),
+    std::shared_ptr<T> & obj,
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
   {
     return subscribe(node, base_topic,
-        std::bind(fp, obj, std::placeholders::_1), custom_qos);
+             std::bind(fp, obj, std::placeholders::_1), custom_qos);
   }
 
   /**
@@ -137,9 +141,10 @@ protected:
   /**
    * \brief Subscribe to an image transport topic. Must be implemented by the subclass.
    */
-  virtual void subscribeImpl(rclcpp::Node::SharedPtr node, const std::string& base_topic,
-                             const Callback& callback,
-                             rmw_qos_profile_t custom_qos = rmw_qos_profile_default) = 0;
+  virtual void subscribeImpl(
+    rclcpp::Node * node, const std::string & base_topic,
+    const Callback & callback,
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default) = 0;
 };
 
 } //namespace image_transport

--- a/image_transport/include/image_transport/transport_hints.h
+++ b/image_transport/include/image_transport/transport_hints.h
@@ -40,7 +40,8 @@
 
 #include <rclcpp/node.hpp>
 
-namespace image_transport {
+namespace image_transport
+{
 
 /**
  * \brief Stores transport settings for an image topic subscription.
@@ -60,14 +61,15 @@ public:
    * @param default_transport Preferred transport to use
    * @param parameter_name The name of the transport parameter
    */
-  TransportHints(const rclcpp::Node::SharedPtr& node,
-                 const std::string& default_transport = "raw",
-                 const std::string& parameter_name = "image_transport")
+  TransportHints(
+    const rclcpp::Node * node,
+    const std::string & default_transport = "raw",
+    const std::string & parameter_name = "image_transport")
   {
     node->get_parameter_or<std::string>(parameter_name, transport_, default_transport);
   }
 
-  const std::string& getTransport() const
+  const std::string & getTransport() const
   {
     return transport_;
   }

--- a/image_transport/src/camera_common.cpp
+++ b/image_transport/src/camera_common.cpp
@@ -33,37 +33,42 @@
 *********************************************************************/
 
 #include "image_transport/camera_common.h"
-#include "rcutils/error_handling.h"
-#include "rcutils/logging_macros.h"
-#include "rcutils/macros.h"
-#include "rcutils/split.h"
+
 #include <vector>
 
 namespace image_transport
 {
 
+std::vector<std::string> split(std::string input,
+                               const std::string & delim)
+{
+  size_t pos = 0;
+  std::vector<std::string> out;
+
+  while ((pos = input.find(delim)) != std::string::npos) {
+    auto token = input.substr(0, pos);
+    if (token.size() > 0) {
+      out.push_back(token);
+    }
+    input.erase(0, pos + delim.length());
+  }
+  out.push_back(input);
+
+  return out;
+}
+
 std::string getCameraInfoTopic(const std::string & base_topic)
 {
   std::string info_topic;
-  rcutils_allocator_t allocator = rcutils_get_default_allocator();
-  rcutils_string_array_t tokens;
+  auto tokens = split(base_topic, "/");
 
-  if (rcutils_split(base_topic.c_str(), '/', allocator, &tokens) != RCUTILS_RET_OK) {
-    RCUTILS_SET_ERROR_MSG(rcutils_get_error_string_safe(), allocator)
-    RCUTILS_LOG_ERROR("%s\n", rcutils_get_error_string_safe());
-  } else {
-    if (tokens.size > 0) {
-      for(size_t ii = 0; ii < tokens.size - 1; ++ii) {
-        info_topic.append("/");
-        info_topic.append(tokens.data[ii]);
-      }
+  if (tokens.size() > 0) {
+    for(size_t ii = 0; ii < tokens.size() - 1; ++ii) {
+      info_topic.append("/");
+      info_topic.append(tokens[ii]);
     }
-    info_topic += "/camera_info";
   }
-
-  if(rcutils_string_array_fini(&tokens) != RCUTILS_RET_OK) {
-    RCUTILS_LOG_ERROR("Failed to destroy the token string array\n");
-  }
+  info_topic += "/camera_info";
 
   return info_topic;
 }

--- a/image_transport/src/camera_publisher.cpp
+++ b/image_transport/src/camera_publisher.cpp
@@ -44,8 +44,8 @@ namespace image_transport
 
 struct CameraPublisher::Impl
 {
-  Impl(rclcpp::Node::SharedPtr node)
-  : logger_(node->get_logger()) ,
+  Impl(rclcpp::Node * node)
+  : logger_(node->get_logger()),
     unadvertised_(false)
   {
   }
@@ -78,7 +78,7 @@ struct CameraPublisher::Impl
 
 //TODO(ros2) Add support for SubscriberStatusCallbacks when rcl/rmw support it.
 CameraPublisher::CameraPublisher(
-  rclcpp::Node::SharedPtr node,
+  rclcpp::Node * node,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos)
 : impl_(std::make_shared<Impl>(node))
@@ -109,7 +109,7 @@ std::string CameraPublisher::getTopic() const
 
 std::string CameraPublisher::getInfoTopic() const
 {
-  if (impl_) return impl_->info_pub_->get_topic_name();
+  if (impl_) {return impl_->info_pub_->get_topic_name();}
   return std::string();
 }
 
@@ -119,7 +119,8 @@ void CameraPublisher::publish(
 {
   if (!impl_ || !impl_->isValid()) {
     // TODO(ros2) Switch to RCUTILS_ASSERT when ros2/rcutils#112 is merged
-    RCLCPP_FATAL(impl_->logger_, "Call to publish() on an invalid image_transport::CameraPublisher");
+    RCLCPP_FATAL(impl_->logger_,
+      "Call to publish() on an invalid image_transport::CameraPublisher");
     return;
   }
 
@@ -133,7 +134,8 @@ void CameraPublisher::publish(
 {
   if (!impl_ || !impl_->isValid()) {
     // TODO(ros2) Switch to RCUTILS_ASSERT when ros2/rcutils#112 is merged
-    RCLCPP_FATAL(impl_->logger_, "Call to publish() on an invalid image_transport::CameraPublisher");
+    RCLCPP_FATAL(impl_->logger_,
+      "Call to publish() on an invalid image_transport::CameraPublisher");
     return;
   }
 

--- a/image_transport/src/camera_subscriber.cpp
+++ b/image_transport/src/camera_subscriber.cpp
@@ -52,7 +52,7 @@ struct CameraSubscriber::Impl
   using CameraInfo = sensor_msgs::msg::CameraInfo;
   using TimeSync = message_filters::TimeSynchronizer<Image, CameraInfo>;
 
-  Impl(rclcpp::Node::SharedPtr node)
+  Impl(rclcpp::Node* node)
   : logger_(node->get_logger()) ,
     sync_(10),
     unsubscribed_(false),
@@ -109,7 +109,7 @@ struct CameraSubscriber::Impl
 };
 
 CameraSubscriber::CameraSubscriber(
-  rclcpp::Node::SharedPtr node,
+  rclcpp::Node * node,
   const std::string & base_topic,
   const Callback & callback,
   const std::string & transport,

--- a/image_transport/src/image_transport.cpp
+++ b/image_transport/src/image_transport.cpp
@@ -60,7 +60,7 @@ struct Impl
 static Impl * kImpl = new Impl();
 
 Publisher create_publisher(
-  rclcpp::Node::SharedPtr node,
+  rclcpp::Node * node,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos)
 {
@@ -68,7 +68,7 @@ Publisher create_publisher(
 }
 
 Subscriber create_subscription(
-  rclcpp::Node::SharedPtr node,
+  rclcpp::Node * node,
   const std::string & base_topic,
   const Subscriber::Callback & callback,
   const std::string & transport,
@@ -78,7 +78,7 @@ Subscriber create_subscription(
 }
 
 CameraPublisher create_camera_publisher(
-  rclcpp::Node::SharedPtr node,
+  rclcpp::Node * node,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos)
 {
@@ -86,7 +86,7 @@ CameraPublisher create_camera_publisher(
 }
 
 CameraSubscriber create_camera_subscription(
-  rclcpp::Node::SharedPtr node,
+  rclcpp::Node * node,
   const std::string & base_topic,
   const CameraSubscriber::Callback & callback,
   const std::string & transport,
@@ -144,7 +144,7 @@ Publisher ImageTransport::advertise(const std::string & base_topic, uint32_t que
   (void) latch;
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
   custom_qos.depth = queue_size;
-  return create_publisher(impl_->node_, base_topic, custom_qos);
+  return create_publisher(impl_->node_.get(), base_topic, custom_qos);
 }
 
 Subscriber ImageTransport::subscribe(
@@ -156,7 +156,7 @@ Subscriber ImageTransport::subscribe(
   (void) tracked_object;
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
   custom_qos.depth = queue_size;
-  return create_subscription(impl_->node_, base_topic, callback,
+  return create_subscription(impl_->node_.get(), base_topic, callback,
            getTransportOrDefault(transport_hints), custom_qos);
 }
 
@@ -168,7 +168,7 @@ CameraPublisher ImageTransport::advertiseCamera(
   (void) latch;
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
   custom_qos.depth = queue_size;
-  return create_camera_publisher(impl_->node_, base_topic, custom_qos);
+  return create_camera_publisher(impl_->node_.get(), base_topic, custom_qos);
 }
 
 CameraSubscriber ImageTransport::subscribeCamera(
@@ -180,7 +180,7 @@ CameraSubscriber ImageTransport::subscribeCamera(
   (void) tracked_object;
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
   custom_qos.depth = queue_size;
-  return create_camera_subscription(impl_->node_, base_topic, callback,
+  return create_camera_subscription(impl_->node_.get(), base_topic, callback,
            getTransportOrDefault(transport_hints), custom_qos);
 }
 
@@ -198,7 +198,7 @@ std::string ImageTransport::getTransportOrDefault(const TransportHints * transpo
 {
   std::string ret;
   if (nullptr == transport_hints) {
-    TransportHints th(impl_->node_);
+    TransportHints th(impl_->node_.get());
     ret = th.getTransport();
   } else {
     ret = transport_hints->getTransport();

--- a/image_transport/src/publisher.cpp
+++ b/image_transport/src/publisher.cpp
@@ -47,7 +47,7 @@ namespace image_transport
 
 struct Publisher::Impl
 {
-  Impl(rclcpp::Node::SharedPtr node)
+  Impl(rclcpp::Node * node)
   : logger_(node->get_logger()),
     unadvertised_(false)
   {
@@ -96,7 +96,7 @@ struct Publisher::Impl
 };
 
 Publisher::Publisher(
-  rclcpp::Node::SharedPtr node, const std::string & base_topic,
+  rclcpp::Node * node, const std::string & base_topic,
   PubLoaderPtr loader, rmw_qos_profile_t custom_qos)
 : impl_(std::make_shared<Impl>(node))
 {

--- a/image_transport/src/subscriber.cpp
+++ b/image_transport/src/subscriber.cpp
@@ -47,7 +47,7 @@ namespace image_transport
 
 struct Subscriber::Impl
 {
-  Impl(rclcpp::Node::SharedPtr node, SubLoaderPtr loader)
+  Impl(rclcpp::Node * node, SubLoaderPtr loader)
   : logger_(node->get_logger()),
     loader_(loader),
     unsubscribed_(false)
@@ -83,11 +83,11 @@ struct Subscriber::Impl
 };
 
 Subscriber::Subscriber(
-  rclcpp::Node::SharedPtr node,
+  rclcpp::Node * node,
   const std::string & base_topic,
   const Callback & callback,
   SubLoaderPtr loader,
-  const std::string& transport,
+  const std::string & transport,
   rmw_qos_profile_t custom_qos)
 : impl_(std::make_shared<Impl>(node, loader))
 {

--- a/image_transport/test/test_message_passing.cpp
+++ b/image_transport/test/test_message_passing.cpp
@@ -82,8 +82,8 @@ TEST_F(MessagePassingTesting, one_message_passing)
 
   rclcpp::executors::SingleThreadedExecutor executor;
 
-  auto pub = image_transport::create_publisher(node_, "camera/image");
-  auto sub = image_transport::create_subscription(node_, "camera/image", imageCallback, "raw");
+  auto pub = image_transport::create_publisher(node_.get(), "camera/image");
+  auto sub = image_transport::create_subscription(node_.get(), "camera/image", imageCallback, "raw");
 
   test_rclcpp::wait_for_subscriber(node_, sub.getTopic());
 
@@ -118,8 +118,8 @@ TEST_F(MessagePassingTesting, one_camera_message_passing)
 
   rclcpp::executors::SingleThreadedExecutor executor;
 
-  auto pub = image_transport::create_camera_publisher(node_, "camera/image");
-  auto sub = image_transport::create_camera_subscription(node_, "camera/image",
+  auto pub = image_transport::create_camera_publisher(node_.get(), "camera/image");
+  auto sub = image_transport::create_camera_subscription(node_.get(), "camera/image",
       [this](const sensor_msgs::msg::Image::ConstSharedPtr& image,
              const sensor_msgs::msg::CameraInfo::ConstSharedPtr& info) {
       (void) image;

--- a/image_transport/test/test_publisher.cpp
+++ b/image_transport/test/test_publisher.cpp
@@ -19,7 +19,7 @@ protected:
 };
 
 TEST_F(TestPublisher, Publisher) {
-  auto pub = image_transport::create_publisher(node_, "camera/image");
+  auto pub = image_transport::create_publisher(node_.get(), "camera/image");
 }
 
 TEST_F(TestPublisher, ImageTransportPublisher) {
@@ -28,7 +28,7 @@ TEST_F(TestPublisher, ImageTransportPublisher) {
 }
 
 TEST_F(TestPublisher, CameraPublisher) {
-  auto camera_pub = image_transport::create_camera_publisher(node_, "camera/image");
+  auto camera_pub = image_transport::create_camera_publisher(node_.get(), "camera/image");
 }
 
 TEST_F(TestPublisher, ImageTransportCameraPublisher) {

--- a/image_transport/test/test_remapping.cpp
+++ b/image_transport/test/test_remapping.cpp
@@ -46,14 +46,14 @@ TEST_F(TestPublisher, Publisher) {
 
   // Subscribe
   bool received{false};
-  auto sub = image_transport::create_subscription(node_remap_, "old_topic",
+  auto sub = image_transport::create_subscription(node_remap_.get(), "old_topic",
     [&received](const sensor_msgs::msg::Image::ConstSharedPtr & msg) {
       (void)msg;
       received = true;
     }, "raw");
 
   // Publish
-  auto pub = image_transport::create_publisher(node_, "new_topic");
+  auto pub = image_transport::create_publisher(node_.get(), "new_topic");
 
   ASSERT_EQ("/namespace/new_topic", sub.getTopic());
   test_rclcpp::wait_for_subscriber(node_remap_, sub.getTopic());

--- a/image_transport/test/test_subscriber.cpp
+++ b/image_transport/test/test_subscriber.cpp
@@ -22,7 +22,7 @@ TEST_F(TestPublisher, construction_and_destruction) {
   std::function<void(const sensor_msgs::msg::Image::ConstSharedPtr & msg)> fcn =
     [](const auto & msg) {(void)msg;};
 
-  auto sub = image_transport::create_subscription(node_, "camera/image", fcn, "raw");
+  auto sub = image_transport::create_subscription(node_.get(), "camera/image", fcn, "raw");
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.spin_node_some(node_);


### PR DESCRIPTION
Change the free function variants of the image_transport API to no longer depend on needed a SharedPtr .

If you want to create image_transport Publishers or Subscribers as part of the subclass constructor, there was no way to get a shared pointer to the node instance itself to pass in. shared_from_this is not allowed in constructors for reasons listed here: https://en.cppreference.com/w/cpp/memory/enable_shared_from_this

If the previous behavior is desired, there is still the image_transport::ImageTransport object.

Requires ros2/message_filters#14