### PR TITLE
[ROS2] fixed file extension check bug

### DIFF
--- a/camera_calibration_parsers/include/camera_calibration_parsers/impl/filesystem_helper.hpp
+++ b/camera_calibration_parsers/include/camera_calibration_parsers/impl/filesystem_helper.hpp
@@ -168,7 +168,7 @@ public:
   {
     auto fname = filename();
     auto split_fname = split(fname.string(), std::string("\\."));
-    return "." + split_fname[1];
+    return "." + split_fname.back();
   }
 
   path operator/(const std::string & other)

--- a/camera_calibration_parsers/include/camera_calibration_parsers/impl/filesystem_helper.hpp
+++ b/camera_calibration_parsers/include/camera_calibration_parsers/impl/filesystem_helper.hpp
@@ -167,8 +167,8 @@ public:
   std::string extension() const
   {
     auto fname = filename();
-    auto split_fname = split(fname.string(), std::string(1, '.'));
-    return "." + *split_fname.end();
+    auto split_fname = split(fname.string(), std::string("\\."));
+    return "." + split_fname[1];
   }
 
   path operator/(const std::string & other)


### PR DESCRIPTION
Fixed a bug which caused the calibration file to always fail the file extension check. Two things seemed amiss: 1. regex was not correct, 2. the dereferenced end of the regex iterator did not give the correct value, so changed that as well.
Working now :) Let me know if you have any feedback or changes to be made.