### PR TITLE
add S_ISDIR macro on Windows

### DIFF
--- a/camera_info_manager/src/camera_info_manager.cpp
+++ b/camera_info_manager/src/camera_info_manager.cpp
@@ -39,7 +39,14 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+#ifdef _WIN32
+  #ifndef S_ISDIR
+    #define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+  #endif
+#else
+  #include <unistd.h>
+#endif
+
 #include <ros/ros.h>
 #include <ros/package.h>
 #include <boost/algorithm/string.hpp>


### PR DESCRIPTION
`S_ISDIR` is not available on Windows, add a macro to enable building on Windows