### PR TITLE
[ros2] Update to use new count APIs

### DIFF
--- a/image_transport/include/image_transport/simple_publisher_plugin.h
+++ b/image_transport/include/image_transport/simple_publisher_plugin.h
@@ -72,9 +72,8 @@ public:
 
   virtual uint32_t getNumSubscribers() const
   {
-    // TODO(mjcarroll) replace with publisher-specific call.
     if (simple_impl_) {
-      return static_cast<uint32_t>(simple_impl_->node_->count_subscribers(getTopic()));
+      return simple_impl_->pub_->get_subscription_count();
     }
     return 0;
   }

--- a/image_transport/include/image_transport/simple_subscriber_plugin.h
+++ b/image_transport/include/image_transport/simple_subscriber_plugin.h
@@ -77,9 +77,10 @@ public:
 
   virtual uint32_t getNumPublishers() const
   {
-    //TODO(ros2) Enable count_publisher when rcl/rmw supports it.
-    //if (simple_impl_) return simple_impl_->node_->count_publishers(getTopic());
-    return 1;
+    if (impl_) {
+      return impl_->sub_->get_publisher_count();
+    }
+    return 0;
   }
 
   virtual void shutdown()
@@ -95,7 +96,7 @@ protected:
    * @param message A message from the PublisherPlugin.
    * @param user_cb The user Image callback to invoke, if appropriate.
    */
- 
+
   virtual void internalCallback(
     const typename std::shared_ptr<const M>& message,
     const Callback & user_cb) = 0;

--- a/image_transport/src/publisher.cpp
+++ b/image_transport/src/publisher.cpp
@@ -104,6 +104,7 @@ Publisher::Publisher(
   // properly (#3652).
   std::string image_topic = rclcpp::expand_topic_or_service_name(base_topic,
       node->get_name(), node->get_namespace());
+  impl_->base_topic_ = image_topic;
   impl_->loader_ = loader;
 
   std::vector<std::string> blacklist_vec;

--- a/image_transport/test/test_remapping.cpp
+++ b/image_transport/test/test_remapping.cpp
@@ -15,9 +15,7 @@ class TestPublisher : public ::testing::Test
 protected:
   void SetUp()
   {
-    rclcpp::NodeOptions node_options_pub;
-    node_ = rclcpp::Node::make_shared("node", "namespace", node_options_pub);
-
+    node_ = rclcpp::Node::make_shared("node", "namespace");
     std::vector<std::string> arguments;
     arguments.push_back("old_topic:=new_topic");
     rclcpp::NodeOptions node_options;


### PR DESCRIPTION
What was here already was stubs from before rclcpp supported retrieving
counts directly from the publisher and subscription.

Signed-off-by: Michael Carroll <michael@openrobotics.org>