### PR TITLE
[ROS2] Fix driver node status check before saving calibration data

### DIFF
--- a/camera_info_manager/src/camera_info_manager.cpp
+++ b/camera_info_manager/src/camera_info_manager.cpp
@@ -526,7 +526,7 @@ CameraInfoManager::setCameraInfoService(
     loaded_cam_info_ = true;
   }
 
-  if (rclcpp::ok()) {
+  if (!rclcpp::ok()) {
     RCLCPP_ERROR(logger_, "set_camera_info service called, but driver not running.");
     rsp->status_message = "Camera driver not running.";
     rsp->success = false;


### PR DESCRIPTION
Fixes #131 , allowing the calibration .yaml file to be saved.

Currently the service fails when `rclcpp::ok()` returns True, which isn't the right behavior. Since this callback previously used `!nh_.ok()` to check the status of the camera driver, I think the ROS2 version should be using `!rclcpp::ok()` here instead.