### PR TITLE
remove check for python3 component of boost

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -4,11 +4,7 @@ project(camera_calibration_parsers)
 find_package(catkin REQUIRED sensor_msgs rosconsole roscpp roscpp_serialization)
 
 find_package(PythonLibs REQUIRED)
-if(PYTHONLIBS_VERSION_STRING VERSION_LESS 3)
-  find_package(Boost REQUIRED COMPONENTS filesystem python)
-else()
-  find_package(Boost REQUIRED COMPONENTS filesystem python3)
-endif()
+find_package(Boost REQUIRED COMPONENTS filesystem python)
 include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS})
 
 catkin_python_setup()


### PR DESCRIPTION
Problem:
With boost version 1.71, calling `find_package(Boost REQUIRED python3)` fails. Boost now defaults to `find_package(Boost REQUIRED python)` for both Python versions. This is causing failure to build for the Arch Linux Melodic packages.

Solution:
This PR fixes the build process for systems that are using Python 3 and boost >= 1.71. For boost < 1.71 the command for Python 2 remains the same.

Issues:
I expect this PR would break systems that do not have Python 2 and have boost >= 1.71, but since Python 2 is required for ROS melodic via [REP 3](https://www.ros.org/reps/rep-0003.html#melodic-morenia-may-2018-may-2023), this should not be a breaking change for existing platforms.
This may become an issue with the Noetic release, since Noetic targets Python 3 only, but we do not know the Boost version Noetic will target (it may be < 1.71).