### PR TITLE
[ros2] add missing set header

### DIFF
--- a/image_transport/src/publisher.cpp
+++ b/image_transport/src/publisher.cpp
@@ -36,6 +36,8 @@
 #include "image_transport/publisher.h"
 #include "image_transport/publisher_plugin.h"
 
+#include <set>
+
 #include <rclcpp/expand_topic_or_service_name.hpp>
 #include <rclcpp/logging.hpp>
 #include <rclcpp/node.hpp>


### PR DESCRIPTION
WIthout this it fails to compile on gcc 9.2 with the following:

```
/tmp/demo_deps_ws/src/image_common/image_transport/src/publisher.cpp:111:8: error: ‘set’ is not a member of ‘std’
  111 |   std::set<std::string> blacklist;
      |        ^~~
/tmp/demo_deps_ws/src/image_common/image_transport/src/publisher.cpp:44:1: note: ‘std::set’ is defined in header ‘<set>’; did you forget to ‘#include <set>’?
```

cc @mjcarroll 


Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>