### PR TITLE
Use PythonInterp for finding the right Boost.python component.

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -4,11 +4,8 @@ project(camera_calibration_parsers)
 find_package(catkin REQUIRED sensor_msgs rosconsole roscpp roscpp_serialization)
 
 find_package(PythonLibs REQUIRED)
-if(PYTHONLIBS_VERSION_STRING VERSION_LESS 3)
-  find_package(Boost REQUIRED COMPONENTS filesystem python)
-else()
-  find_package(Boost REQUIRED COMPONENTS filesystem python3)
-endif()
+find_package(PythonInterp REQUIRED)
+find_package(Boost REQUIRED COMPONENTS filesystem python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
 include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS})
 
 catkin_python_setup()


### PR DESCRIPTION
Since Boost 1.71, they ship their own CMake config file. This config file can't find Boost.python in the following way:
```
find_package(Boost REQUIRED COMPONENTS python3)
```
It has to include the minor version now as well, so for instance:
```
find_package(Boost REQUIRED COMPONENTS python37)
```
To make it more future proof, I use the PythonInterp cmake module to get the major and minor version of python and then use those to find the python component.