### PR TITLE
Fix invalid memory read/write in getCameraInfoTopic() for empty base_topic

### DIFF
--- a/image_transport/src/camera_common.cpp
+++ b/image_transport/src/camera_common.cpp
@@ -33,26 +33,16 @@
 *********************************************************************/
 
 #include "image_transport/camera_common.h"
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/algorithm/string/join.hpp>
-#include <vector>
 
 namespace image_transport {
 
 std::string getCameraInfoTopic(const std::string& base_topic)
 {
-  // Split into separate names
-  std::vector<std::string> names;
-  boost::algorithm::split(names, base_topic, boost::algorithm::is_any_of("/"),
-                          boost::algorithm::token_compress_on);
-  // Get rid of empty tokens from trailing slashes
-  while (names.back().empty())
-    names.pop_back();
-  // Replace image name with "camera_info"
-  names.back() = "camera_info";
-  // Join back together into topic name
-  return boost::algorithm::join(names, "/");
+  size_t pos = base_topic.find_last_of('/');
+  if (pos == std::string::npos)
+    pos = 0;
+  // replace last component of topic path with "camera_info"
+  return base_topic.substr(0, pos) + "camera_info";
 }
 
 } //namespace image_transport


### PR DESCRIPTION
When passing an empty string to getCameraInfoTopic(), boost's split()
was returning an empty vector. However, the last element of this vector
[was accessed w/o protection](https://github.com/ros-perception/image_common/compare/hydro-devel...rhaschke:hydro-devel#diff-7725be884becee139ae68a008e2a1437L53) and even overwritten, causing arbitrary memory corruption.

The new implementation is more efficient, just searching for the last
slash and replacing everything thereafter with "camera_info".