### PR TITLE
Bump CMake version to avoid CMP0048

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 project(camera_calibration_parsers)
 
 find_package(catkin REQUIRED sensor_msgs rosconsole roscpp roscpp_serialization)

--- a/camera_info_manager/CMakeLists.txt
+++ b/camera_info_manager/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 project(camera_info_manager)
 
 find_package(catkin REQUIRED COMPONENTS camera_calibration_parsers image_transport roscpp roslib sensor_msgs)

--- a/image_common/CMakeLists.txt
+++ b/image_common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(image_common)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/image_transport/CMakeLists.txt
+++ b/image_transport/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(image_transport)
 
 find_package(catkin REQUIRED

--- a/image_transport/tutorial/CMakeLists.txt
+++ b/image_transport/tutorial/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 project(image_transport_tutorial)
 
 find_package(catkin REQUIRED COMPONENTS cv_bridge image_transport message_generation sensor_msgs)

--- a/polled_camera/CMakeLists.txt
+++ b/polled_camera/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 project(polled_camera)
 
 # generate the server


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

Since this version is greater than the version supported by ROS Hydro, it should probably be retargeted at a newly created `kinetic-devel` or `noetic-devel` branch.

ros/catkin#1052