### PR TITLE
[ros2] Adding visibility control headers for Windows build

### DIFF
--- a/camera_info_manager/CMakeLists.txt
+++ b/camera_info_manager/CMakeLists.txt
@@ -11,6 +11,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+if(MSVC)
+  add_compile_definitions(_SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING)
+endif()
+
 find_package(ament_cmake_ros REQUIRED)
 
 find_package(ament_index_cpp REQUIRED)
@@ -23,6 +27,8 @@ include_directories(include)
 
 # add a library
 add_library(${PROJECT_NAME} src/camera_info_manager.cpp)
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE "CAMERA_INFO_MANAGER_BUILDING_DLL")
 
 ament_target_dependencies(
   ${PROJECT_NAME}

--- a/camera_info_manager/include/camera_info_manager/camera_info_manager.h
+++ b/camera_info_manager/include/camera_info_manager/camera_info_manager.h
@@ -45,6 +45,7 @@
 #include "rclcpp/node.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/srv/set_camera_info.hpp"
+#include "camera_info_manager/visibility_control.h"
 
 /** @file
 
@@ -177,7 +178,7 @@ using SetCameraInfo = sensor_msgs::srv::SetCameraInfo;
 
 */
 
-class CameraInfoManager
+class CAMERA_INFO_MANAGER_PUBLIC CameraInfoManager
 {
 public:
   CameraInfoManager(

--- a/camera_info_manager/include/camera_info_manager/visibility_control.h
+++ b/camera_info_manager/include/camera_info_manager/visibility_control.h
@@ -1,0 +1,56 @@
+// Copyright 2020 Microsoft Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* This header must be included by all rclcpp headers which declare symbols
+ * which are defined in the rclcpp library. When not building the rclcpp
+ * library, i.e. when using the headers in other package's code, the contents
+ * of this header change the visibility of certain symbols which the rclcpp
+ * library cannot have, but the consuming code must have inorder to link.
+ */
+
+#ifndef CAMERA_INFO_MANAGER__VISIBILITY_CONTROL_H_
+#define CAMERA_INFO_MANAGER__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define CAMERA_INFO_MANAGER_EXPORT __attribute__ ((dllexport))
+    #define CAMERA_INFO_MANAGER_IMPORT __attribute__ ((dllimport))
+  #else
+    #define CAMERA_INFO_MANAGER_EXPORT __declspec(dllexport)
+    #define CAMERA_INFO_MANAGER_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef CAMERA_INFO_MANAGER_BUILDING_DLL
+    #define CAMERA_INFO_MANAGER_PUBLIC CAMERA_INFO_MANAGER_EXPORT
+  #else
+    #define CAMERA_INFO_MANAGER_PUBLIC CAMERA_INFO_MANAGER_IMPORT
+  #endif
+  #define CAMERA_INFO_MANAGER_PUBLIC_TYPE CAMERA_INFO_MANAGER_PUBLIC
+  #define CAMERA_INFO_MANAGER_LOCAL
+#else
+  #define CAMERA_INFO_MANAGER_EXPORT __attribute__ ((visibility("default")))
+  #define CAMERA_INFO_MANAGER_IMPORT
+  #if __GNUC__ >= 4
+    #define CAMERA_INFO_MANAGER_PUBLIC __attribute__ ((visibility("default")))
+    #define CAMERA_INFO_MANAGER_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define CAMERA_INFO_MANAGER_PUBLIC
+    #define CAMERA_INFO_MANAGER_LOCAL
+  #endif
+  #define CAMERA_INFO_MANAGER_PUBLIC_TYPE
+#endif
+
+#endif  // CAMERA_INFO_MANAGER__VISIBILITY_CONTROL_H_


### PR DESCRIPTION
* Adding visibility control headers for Windows build
* Defined `_SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING` to ack the `<experimental/filesystem>` usage on `MSVC`. Otherwise, it manifests as a compile error.