### PR TITLE
support lifecycle nodes

### DIFF
--- a/image_transport/include/image_transport/camera_publisher.hpp
+++ b/image_transport/include/image_transport/camera_publisher.hpp
@@ -76,6 +76,26 @@ public:
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
 
+  IMAGE_TRANSPORT_PUBLIC
+  CameraPublisher(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface,
+    const std::string & base_topic,
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+
+  template<class NodeT>
+  CameraPublisher(
+    NodeT && node,
+    const std::string & base_topic,
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+  : CameraPublisher(
+      node->get_node_base_interface(),
+      node->get_node_topics_interface(),
+      node->get_node_logging_interface(),
+      base_topic, custom_qos)
+  {}
+
   //TODO(ros2) Restore support for SubscriberStatusCallbacks when available.
 
   /*!

--- a/image_transport/include/image_transport/camera_subscriber.hpp
+++ b/image_transport/include/image_transport/camera_subscriber.hpp
@@ -79,6 +79,25 @@ public:
                    const std::string& transport,
                    rmw_qos_profile_t = rmw_qos_profile_default);
 
+  IMAGE_TRANSPORT_PUBLIC
+  CameraSubscriber(
+                   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+                   rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
+                   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface,
+                   const std::string& base_topic,
+                   const Callback& callback,
+                   const std::string& transport,
+                   rmw_qos_profile_t = rmw_qos_profile_default);
+
+  template<class NodeT>
+  CameraSubscriber(NodeT && node,
+                  const std::string& base_topic,
+                  const Callback& callback,
+                  const std::string& transport,
+                  rmw_qos_profile_t = rmw_qos_profile_default)
+  : CameraSubscriber(node->get_node_base_interface(), node->get_node_topics_interface(), node->get_node_logging_interface(), base_topic, callback, transport)
+  {}
+
   /**
    * \brief Get the base topic (on which the raw image is published).
    */

--- a/image_transport/include/image_transport/image_transport.hpp
+++ b/image_transport/include/image_transport/image_transport.hpp
@@ -61,12 +61,30 @@ Publisher create_publisher(
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
 
+IMAGE_TRANSPORT_PUBLIC
+Publisher create_publisher(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface,
+  const std::string & base_topic,
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+
 /**
  * \brief Subscribe to an image topic, free function version.
  */
 IMAGE_TRANSPORT_PUBLIC
 Subscriber create_subscription(
   rclcpp::Node* node,
+  const std::string & base_topic,
+  const Subscriber::Callback & callback,
+  const std::string & transport,
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+
+IMAGE_TRANSPORT_PUBLIC
+Subscriber create_subscription(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface,
   const std::string & base_topic,
   const Subscriber::Callback & callback,
   const std::string & transport,
@@ -81,12 +99,30 @@ CameraPublisher create_camera_publisher(
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
 
+IMAGE_TRANSPORT_PUBLIC
+CameraPublisher create_camera_publisher(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface,
+  const std::string & base_topic,
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+
 /*!
  * \brief Subscribe to a camera, free function version.
  */
 IMAGE_TRANSPORT_PUBLIC
 CameraSubscriber create_camera_subscription(
   rclcpp::Node* node,
+  const std::string & base_topic,
+  const CameraSubscriber::Callback & callback,
+  const std::string & transport,
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+
+IMAGE_TRANSPORT_PUBLIC
+CameraSubscriber create_camera_subscription(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface,
   const std::string & base_topic,
   const CameraSubscriber::Callback & callback,
   const std::string & transport,
@@ -114,6 +150,17 @@ public:
 
   IMAGE_TRANSPORT_PUBLIC
   explicit ImageTransport(rclcpp::Node::SharedPtr node);
+
+  IMAGE_TRANSPORT_PUBLIC
+  ImageTransport(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface);
+
+  template<class NodeT>
+  explicit ImageTransport(NodeT && node)
+  : ImageTransport(node->get_node_base_interface(), node->get_node_topics_interface(), node->get_node_logging_interface())
+  {}
 
   IMAGE_TRANSPORT_PUBLIC
   ~ImageTransport();

--- a/image_transport/include/image_transport/publisher.hpp
+++ b/image_transport/include/image_transport/publisher.hpp
@@ -75,10 +75,31 @@ public:
 
   IMAGE_TRANSPORT_PUBLIC
   Publisher(
-    rclcpp::Node * nh,
+    rclcpp::Node * node,
     const std::string & base_topic,
     PubLoaderPtr loader,
     rmw_qos_profile_t custom_qos);
+
+  template<class NodeT>
+  Publisher(
+    NodeT && node,
+    const std::string & base_topic,
+    PubLoaderPtr loader,
+    rmw_qos_profile_t custom_qos)
+  : Publisher(
+      node->get_node_base_interface(),
+      node->get_node_topics_interface(),
+      node->get_node_logging_interface(),
+      base_topic, loader, custom_qos)
+  {}
+
+  IMAGE_TRANSPORT_PUBLIC
+  Publisher(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface,
+    const std::string & base_topic,
+    PubLoaderPtr loader, rmw_qos_profile_t custom_qos);
 
   /*!
    * \brief Returns the number of subscribers that are currently connected to

--- a/image_transport/include/image_transport/subscriber.hpp
+++ b/image_transport/include/image_transport/subscriber.hpp
@@ -81,6 +81,26 @@ public:
     const std::string & transport,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
 
+  IMAGE_TRANSPORT_PUBLIC
+  Subscriber(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface,
+    const std::string & base_topic,
+    const Callback & callback,
+    SubLoaderPtr loader,
+    const std::string & transport,
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+
+  template<class NodeT>
+  Subscriber(NodeT && node,
+                  const std::string& base_topic,
+                  const Callback& callback,
+                  const std::string& transport,
+                  rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+  : Subscriber(node->get_node_base_interface(), node->get_node_topics_interface(), node->get_node_logging_interface(), base_topic, callback, transport, custom_qos)
+  {}
+
   /**
    * \brief Returns the base image topic.
    *


### PR DESCRIPTION
closes #108 

Currently still in draft mode. Call for participation. 

The current architecture of image transport is pretty complex for easily integrating lifecycle nodes as `rclcpp::Nodes` are passed along pretty heavily. Hence, all functions are basically overloaded to deal with their individual node interfaces to avoid templating.