### PR TITLE
fix mistyping 'cammera_publisher.hpp -> camera_publisher.hpp'

### DIFF
--- a/image_transport/include/image_transport/camera_publisher.h
+++ b/image_transport/include/image_transport/camera_publisher.h
@@ -38,8 +38,8 @@
 #ifndef IMAGE_TRANSPORT__CAMERA_PUBLISHER_H_
 #define IMAGE_TRANSPORT__CAMERA_PUBLISHER_H_
 
-#pragma message ("Warning: This header is deprecated. Use 'cammera_publisher.hpp' instead")
+#pragma message ("Warning: This header is deprecated. Use 'camera_publisher.hpp' instead")
 
-#include "cammera_publisher.hpp"
+#include "camera_publisher.hpp"
 
 #endif  // IMAGE_TRANSPORT__CAMERA_PUBLISHER_H_

--- a/image_transport/include/image_transport/camera_publisher.h
+++ b/image_transport/include/image_transport/camera_publisher.h
@@ -38,7 +38,7 @@
 #ifndef IMAGE_TRANSPORT__CAMERA_PUBLISHER_H_
 #define IMAGE_TRANSPORT__CAMERA_PUBLISHER_H_
 
-#pragma message ("Warning: This header is deprecated. Use 'cammera_publisher.hpp' instead")
+#pragma message ("Warning: This header is deprecated. Use 'camera_publisher.hpp' instead")
 
 #include "cammera_publisher.hpp"
 


### PR DESCRIPTION
Because of mistyping, camera_publisher.h is linking wrong hpp file.