### PR TITLE
Correct QoS for images and use rclcpp::QoS

### DIFF
--- a/image_transport/include/image_transport/camera_publisher.hpp
+++ b/image_transport/include/image_transport/camera_publisher.hpp
@@ -74,7 +74,7 @@ public:
   CameraPublisher(
     rclcpp::Node * node,
     const std::string & base_topic,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+    const rclcpp::QoS & custom_qos = rclcpp::SensorDataQoS());
 
   //TODO(ros2) Restore support for SubscriberStatusCallbacks when available.
 

--- a/image_transport/include/image_transport/camera_subscriber.hpp
+++ b/image_transport/include/image_transport/camera_subscriber.hpp
@@ -77,7 +77,7 @@ public:
                    const std::string& base_topic,
                    const Callback& callback,
                    const std::string& transport,
-                   rmw_qos_profile_t = rmw_qos_profile_default);
+                   const rclcpp::QoS& qos = rclcpp::SensorDataQoS());
 
   /**
    * \brief Get the base topic (on which the raw image is published).

--- a/image_transport/include/image_transport/image_transport.hpp
+++ b/image_transport/include/image_transport/image_transport.hpp
@@ -59,7 +59,7 @@ IMAGE_TRANSPORT_PUBLIC
 Publisher create_publisher(
   rclcpp::Node* node,
   const std::string & base_topic,
-  rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+  const rclcpp::QoS & custom_qos = rclcpp::SensorDataQoS());
 
 /**
  * \brief Subscribe to an image topic, free function version.
@@ -70,7 +70,7 @@ Subscriber create_subscription(
   const std::string & base_topic,
   const Subscriber::Callback & callback,
   const std::string & transport,
-  rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+  const rclcpp::QoS & custom_qos = rclcpp::SensorDataQoS());
 
 /*!
  * \brief Advertise a camera, free function version.
@@ -79,7 +79,7 @@ IMAGE_TRANSPORT_PUBLIC
 CameraPublisher create_camera_publisher(
   rclcpp::Node* node,
   const std::string & base_topic,
-  rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+  const rclcpp::QoS & custom_qos = rclcpp::SensorDataQoS());
 
 /*!
  * \brief Subscribe to a camera, free function version.
@@ -90,7 +90,7 @@ CameraSubscriber create_camera_subscription(
   const std::string & base_topic,
   const CameraSubscriber::Callback & callback,
   const std::string & transport,
-  rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+  const rclcpp::QoS & custom_qos = rclcpp::SensorDataQoS());
 
 IMAGE_TRANSPORT_PUBLIC
 std::vector<std::string> getDeclaredTransports();

--- a/image_transport/include/image_transport/publisher.hpp
+++ b/image_transport/include/image_transport/publisher.hpp
@@ -78,7 +78,7 @@ public:
     rclcpp::Node * nh,
     const std::string & base_topic,
     PubLoaderPtr loader,
-    rmw_qos_profile_t custom_qos);
+    const rclcpp::QoS & custom_qos);
 
   /*!
    * \brief Returns the number of subscribers that are currently connected to

--- a/image_transport/include/image_transport/publisher_plugin.hpp
+++ b/image_transport/include/image_transport/publisher_plugin.hpp
@@ -68,7 +68,7 @@ public:
   void advertise(
     rclcpp::Node * nh,
     const std::string & base_topic,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    const rclcpp::QoS & custom_qos = rclcpp::SensorDataQoS())
   {
     advertiseImpl(nh, base_topic, custom_qos);
   }
@@ -138,7 +138,7 @@ protected:
    */
   virtual void advertiseImpl(
     rclcpp::Node * nh, const std::string & base_topic,
-    rmw_qos_profile_t custom_qos) = 0;
+    const rclcpp::QoS & custom_qos) = 0;
 };
 
 }  // namespace image_transport

--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -103,14 +103,13 @@ public:
 protected:
   virtual void advertiseImpl(
     rclcpp::Node * node, const std::string & base_topic,
-    rmw_qos_profile_t custom_qos)
+    const rclcpp::QoS & custom_qos)
   {
     std::string transport_topic = getTopicToAdvertise(base_topic);
     simple_impl_ = std::make_unique<SimplePublisherPluginImpl>(node);
 
     RCLCPP_DEBUG(simple_impl_->logger_, "getTopicToAdvertise: %s", transport_topic.c_str());
-    auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
-    simple_impl_->pub_ = node->create_publisher<M>(transport_topic, qos);
+    simple_impl_->pub_ = node->create_publisher<M>(transport_topic, custom_qos);
   }
 
   //! Generic function for publishing the internal message type.

--- a/image_transport/include/image_transport/simple_subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/simple_subscriber_plugin.hpp
@@ -116,14 +116,13 @@ protected:
     rclcpp::Node * node,
     const std::string & base_topic,
     const Callback & callback,
-    rmw_qos_profile_t custom_qos)
+    const rclcpp::QoS & custom_qos)
   {
     impl_ = std::make_unique<Impl>();
     // Push each group of transport-specific parameters into a separate sub-namespace
     //ros::NodeHandle param_nh(transport_hints.getParameterNH(), getTransportName());
     //
-    auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
-    impl_->sub_ = node->create_subscription<M>(getTopicToSubscribe(base_topic), qos,
+    impl_->sub_ = node->create_subscription<M>(getTopicToSubscribe(base_topic), custom_qos,
         [this, callback](const typename std::shared_ptr<const M> msg){
           internalCallback(msg, callback);
         });

--- a/image_transport/include/image_transport/subscriber.hpp
+++ b/image_transport/include/image_transport/subscriber.hpp
@@ -79,7 +79,7 @@ public:
     const Callback & callback,
     SubLoaderPtr loader,
     const std::string & transport,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+    const rclcpp::QoS & custom_qos = rclcpp::SensorDataQoS());
 
   /**
    * \brief Returns the base image topic.

--- a/image_transport/include/image_transport/subscriber_filter.hpp
+++ b/image_transport/include/image_transport/subscriber_filter.hpp
@@ -83,9 +83,10 @@ public:
   IMAGE_TRANSPORT_PUBLIC
   SubscriberFilter(
     rclcpp::Node * node, const std::string & base_topic,
-    const std::string & transport)
+    const std::string & transport,
+    const rclcpp::QoS & custom_qos = rclcpp::SensorDataQoS())
   {
-    subscribe(node, base_topic, transport);
+    subscribe(node, base_topic, transport, custom_qos);
   }
 
   /**
@@ -115,7 +116,7 @@ public:
     rclcpp::Node * node,
     const std::string & base_topic,
     const std::string & transport,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    const rclcpp::QoS & custom_qos = rclcpp::SensorDataQoS())
   {
     unsubscribe();
     sub_ =

--- a/image_transport/include/image_transport/subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/subscriber_plugin.hpp
@@ -70,7 +70,7 @@ public:
   void subscribe(
     rclcpp::Node * node, const std::string & base_topic,
     const Callback & callback,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    const rclcpp::QoS & custom_qos = rclcpp::SensorDataQoS())
   {
     return subscribeImpl(node, base_topic, callback, custom_qos);
   }
@@ -81,7 +81,7 @@ public:
   void subscribe(
     rclcpp::Node * node, const std::string & base_topic,
     void (*fp)(const sensor_msgs::msg::Image::ConstSharedPtr &),
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    const rclcpp::QoS & custom_qos = rclcpp::SensorDataQoS())
   {
     return subscribe(node, base_topic,
              std::function<void(const sensor_msgs::msg::Image::ConstSharedPtr &)>(fp),
@@ -95,7 +95,7 @@ public:
   void subscribe(
     rclcpp::Node * node, const std::string & base_topic,
     void (T::* fp)(const sensor_msgs::msg::Image::ConstSharedPtr &), T * obj,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    const rclcpp::QoS & custom_qos = rclcpp::SensorDataQoS())
   {
     return subscribe(node, base_topic,
              std::bind(fp, obj, std::placeholders::_1), custom_qos);
@@ -109,7 +109,7 @@ public:
     rclcpp::Node * node, const std::string & base_topic,
     void (T::* fp)(const sensor_msgs::msg::Image::ConstSharedPtr &),
     std::shared_ptr<T> & obj,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    const rclcpp::QoS & custom_qos = rclcpp::SensorDataQoS())
   {
     return subscribe(node, base_topic,
              std::bind(fp, obj, std::placeholders::_1), custom_qos);
@@ -146,7 +146,7 @@ protected:
   virtual void subscribeImpl(
     rclcpp::Node * node, const std::string & base_topic,
     const Callback & callback,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default) = 0;
+    const rclcpp::QoS & custom_qos) = 0;
 };
 
 }  // namespace image_transport

--- a/image_transport/src/camera_publisher.cpp
+++ b/image_transport/src/camera_publisher.cpp
@@ -82,7 +82,7 @@ struct CameraPublisher::Impl
 CameraPublisher::CameraPublisher(
   rclcpp::Node * node,
   const std::string & base_topic,
-  rmw_qos_profile_t custom_qos)
+  const rclcpp::QoS & custom_qos)
 : impl_(std::make_shared<Impl>(node))
 {
   // Explicitly resolve name here so we compute the correct CameraInfo topic when the
@@ -91,9 +91,10 @@ CameraPublisher::CameraPublisher(
       node->get_name(), node->get_namespace());
   std::string info_topic = getCameraInfoTopic(image_topic);
 
-  auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
   impl_->image_pub_ = image_transport::create_publisher(node, image_topic, custom_qos);
-  impl_->info_pub_ = node->create_publisher<sensor_msgs::msg::CameraInfo>(info_topic, qos);
+  rclcpp::QoS custom_qos_transient = custom_qos;
+  custom_qos_transient.transient_local();
+  impl_->info_pub_ = node->create_publisher<sensor_msgs::msg::CameraInfo>(info_topic, custom_qos_transient);
 }
 
 size_t CameraPublisher::getNumSubscribers() const

--- a/image_transport/src/camera_publisher.cpp
+++ b/image_transport/src/camera_publisher.cpp
@@ -93,7 +93,7 @@ CameraPublisher::CameraPublisher(
 
   impl_->image_pub_ = image_transport::create_publisher(node, image_topic, custom_qos);
   rclcpp::QoS custom_qos_transient = custom_qos;
-  custom_qos_transient.transient_local();
+  custom_qos_transient.transient_local().reliable();
   impl_->info_pub_ = node->create_publisher<sensor_msgs::msg::CameraInfo>(info_topic, custom_qos_transient);
 }
 

--- a/image_transport/src/camera_subscriber.cpp
+++ b/image_transport/src/camera_subscriber.cpp
@@ -126,7 +126,7 @@ CameraSubscriber::CameraSubscriber(
 
   impl_->image_sub_.subscribe(node, image_topic, transport, custom_qos);
   rclcpp::QoS custom_qos_transient = custom_qos;
-  custom_qos_transient.transient_local();
+  custom_qos_transient.transient_local().reliable();
   impl_->info_sub_.subscribe(node, info_topic, custom_qos_transient);
 
   impl_->sync_.connectInput(impl_->image_sub_, impl_->info_sub_);

--- a/image_transport/src/camera_subscriber.cpp
+++ b/image_transport/src/camera_subscriber.cpp
@@ -115,7 +115,7 @@ CameraSubscriber::CameraSubscriber(
   const std::string & base_topic,
   const Callback & callback,
   const std::string & transport,
-  rmw_qos_profile_t custom_qos)
+  const rclcpp::QoS & custom_qos)
 : impl_(std::make_shared<Impl>(node))
 {
   // Must explicitly remap the image topic since we then do some string manipulation on it
@@ -125,7 +125,9 @@ CameraSubscriber::CameraSubscriber(
   std::string info_topic = getCameraInfoTopic(image_topic);
 
   impl_->image_sub_.subscribe(node, image_topic, transport, custom_qos);
-  impl_->info_sub_.subscribe(node, info_topic, custom_qos);
+  rclcpp::QoS custom_qos_transient = custom_qos;
+  custom_qos_transient.transient_local();
+  impl_->info_sub_.subscribe(node, info_topic, custom_qos_transient);
 
   impl_->sync_.connectInput(impl_->image_sub_, impl_->info_sub_);
   impl_->sync_.registerCallback(std::bind(callback, std::placeholders::_1, std::placeholders::_2));

--- a/image_transport/src/image_transport.cpp
+++ b/image_transport/src/image_transport.cpp
@@ -145,7 +145,7 @@ Publisher ImageTransport::advertise(const std::string & base_topic, uint32_t que
 {
   // TODO(ros2) implement when resolved: https://github.com/ros2/ros2/issues/464
   (void) latch;
-  return create_publisher(impl_->node_.get(), base_topic, rclcpp::QoS(queue_size));
+  return create_publisher(impl_->node_.get(), base_topic, rclcpp::SensorDataQoS());
 }
 
 Subscriber ImageTransport::subscribe(
@@ -156,7 +156,7 @@ Subscriber ImageTransport::subscribe(
 {
   (void) tracked_object;
   return create_subscription(impl_->node_.get(), base_topic, callback,
-           getTransportOrDefault(transport_hints), rclcpp::QoS(queue_size));
+           getTransportOrDefault(transport_hints), rclcpp::SensorDataQoS());
 }
 
 CameraPublisher ImageTransport::advertiseCamera(
@@ -165,7 +165,7 @@ CameraPublisher ImageTransport::advertiseCamera(
 {
   // TODO(ros2) implement when resolved: https://github.com/ros2/ros2/issues/464
   (void) latch;
-  return create_camera_publisher(impl_->node_.get(), base_topic, rclcpp::QoS(queue_size));
+  return create_camera_publisher(impl_->node_.get(), base_topic, rclcpp::SensorDataQoS());
 }
 
 CameraSubscriber ImageTransport::subscribeCamera(
@@ -176,7 +176,7 @@ CameraSubscriber ImageTransport::subscribeCamera(
 {
   (void) tracked_object;
   return create_camera_subscription(impl_->node_.get(), base_topic, callback,
-           getTransportOrDefault(transport_hints), rclcpp::QoS(queue_size));
+           getTransportOrDefault(transport_hints), rclcpp::SensorDataQoS());
 }
 
 std::vector<std::string> ImageTransport::getDeclaredTransports() const

--- a/image_transport/src/image_transport.cpp
+++ b/image_transport/src/image_transport.cpp
@@ -63,7 +63,7 @@ static Impl * kImpl = new Impl();
 Publisher create_publisher(
   rclcpp::Node * node,
   const std::string & base_topic,
-  rmw_qos_profile_t custom_qos)
+  const rclcpp::QoS & custom_qos)
 {
   return Publisher(node, base_topic, kImpl->pub_loader_, custom_qos);
 }
@@ -73,7 +73,7 @@ Subscriber create_subscription(
   const std::string & base_topic,
   const Subscriber::Callback & callback,
   const std::string & transport,
-  rmw_qos_profile_t custom_qos)
+  const rclcpp::QoS & custom_qos)
 {
   return Subscriber(node, base_topic, callback, kImpl->sub_loader_, transport, custom_qos);
 }
@@ -81,7 +81,7 @@ Subscriber create_subscription(
 CameraPublisher create_camera_publisher(
   rclcpp::Node * node,
   const std::string & base_topic,
-  rmw_qos_profile_t custom_qos)
+  const rclcpp::QoS & custom_qos)
 {
   return CameraPublisher(node, base_topic, custom_qos);
 }
@@ -91,7 +91,7 @@ CameraSubscriber create_camera_subscription(
   const std::string & base_topic,
   const CameraSubscriber::Callback & callback,
   const std::string & transport,
-  rmw_qos_profile_t custom_qos)
+  const rclcpp::QoS & custom_qos)
 {
   return CameraSubscriber(node, base_topic, callback, transport, custom_qos);
 }
@@ -145,9 +145,7 @@ Publisher ImageTransport::advertise(const std::string & base_topic, uint32_t que
 {
   // TODO(ros2) implement when resolved: https://github.com/ros2/ros2/issues/464
   (void) latch;
-  rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
-  custom_qos.depth = queue_size;
-  return create_publisher(impl_->node_.get(), base_topic, custom_qos);
+  return create_publisher(impl_->node_.get(), base_topic, rclcpp::QoS(queue_size));
 }
 
 Subscriber ImageTransport::subscribe(
@@ -157,10 +155,8 @@ Subscriber ImageTransport::subscribe(
   const TransportHints * transport_hints)
 {
   (void) tracked_object;
-  rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
-  custom_qos.depth = queue_size;
   return create_subscription(impl_->node_.get(), base_topic, callback,
-           getTransportOrDefault(transport_hints), custom_qos);
+           getTransportOrDefault(transport_hints), rclcpp::QoS(queue_size));
 }
 
 CameraPublisher ImageTransport::advertiseCamera(
@@ -169,9 +165,7 @@ CameraPublisher ImageTransport::advertiseCamera(
 {
   // TODO(ros2) implement when resolved: https://github.com/ros2/ros2/issues/464
   (void) latch;
-  rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
-  custom_qos.depth = queue_size;
-  return create_camera_publisher(impl_->node_.get(), base_topic, custom_qos);
+  return create_camera_publisher(impl_->node_.get(), base_topic, rclcpp::QoS(queue_size));
 }
 
 CameraSubscriber ImageTransport::subscribeCamera(
@@ -181,10 +175,8 @@ CameraSubscriber ImageTransport::subscribeCamera(
   const TransportHints * transport_hints)
 {
   (void) tracked_object;
-  rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
-  custom_qos.depth = queue_size;
   return create_camera_subscription(impl_->node_.get(), base_topic, callback,
-           getTransportOrDefault(transport_hints), custom_qos);
+           getTransportOrDefault(transport_hints), rclcpp::QoS(queue_size));
 }
 
 std::vector<std::string> ImageTransport::getDeclaredTransports() const

--- a/image_transport/src/publisher.cpp
+++ b/image_transport/src/publisher.cpp
@@ -100,7 +100,7 @@ struct Publisher::Impl
 
 Publisher::Publisher(
   rclcpp::Node * node, const std::string & base_topic,
-  PubLoaderPtr loader, rmw_qos_profile_t custom_qos)
+  PubLoaderPtr loader, const rclcpp::QoS & custom_qos)
 : impl_(std::make_shared<Impl>(node))
 {
   // Resolve the name explicitly because otherwise the compressed topics don't remap

--- a/image_transport/src/subscriber.cpp
+++ b/image_transport/src/subscriber.cpp
@@ -89,7 +89,7 @@ Subscriber::Subscriber(
   const Callback & callback,
   SubLoaderPtr loader,
   const std::string & transport,
-  rmw_qos_profile_t custom_qos)
+  const rclcpp::QoS & custom_qos)
 : impl_(std::make_shared<Impl>(node, loader))
 {
   // Load the plugin for the chosen transport.


### PR DESCRIPTION
Hi All

This PR is related to https://github.com/ros2/message_filters/pull/51 and https://discourse.ros.org/t/about-qos-of-images/18744

* Change QoS to new API
* Use `rclcpp::SensorDataQoS()` by default for images and `rclcpp::Qos(N).transient_local()` for `camera_info`.

Best

Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>