### PR TITLE
adding image-transport-plugins dependency to image_transport

### DIFF
--- a/image_transport/package.xml
+++ b/image_transport/package.xml
@@ -23,6 +23,7 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
+  <depend>image_transport_plugins</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Adding dependency to install ros-foxy-image-transport-plugins.

`image_transport` load plugins that are contained in `image_transport_plugins` but `image_transport` package doesn't have `image_transport_plugins` dependency.

In ROS1, `image_transport_plugins` was installed as a dependency of `ros-distro-desktop-full `.
```
$ sudo apt-cache rdepends ros-noetic-image-transport-plugins
ros-noetic-image-transport-plugins
Reverse Depends:
  ros-noetic-dnn-detect
  ros-noetic-ros-ign-gazebo-demos
  ros-noetic-perception
$ sudo apt-cache rdepends ros-noetic-perception
ros-noetic-perception
Reverse Depends:
  ros-noetic-desktop-full
```
So this dependency problem haven't discovered for now.

But in ROS2, there is a package that has `image_transport_plugins` dependency only `gazebo-demos`.
```
$ sudo apt-cache rdepends ros-foxy-image-transport-plugins 
ros-foxy-image-transport-plugins
Reverse Depends:
  ros-foxy-ros-ign-gazebo-demos
$ sudo apt-cache rdepends ros-foxy-ros-ign-gazebo-demos
ros-foxy-ros-ign-gazebo-demos
Reverse Depends:
  ros-foxy-ros-ign
$ sudo apt-cache rdepends ros-foxy-ros-ign
ros-foxy-ros-ign
Reverse Depends:
```

One option is to port metapackages to ros2, but there seems to be no plans for now.
https://github.com/ros/metapackages/blob/noetic-devel/perception/package.xml#L23

So, I've added image_transport_plugins dependency on this repository.

I think these issues will be resolved by this PR. https://github.com/ros-perception/image_common/issues/162, https://github.com/ros-perception/image_common/issues/113