### PR TITLE
Fix SimpleSubscriberPlugin

### DIFF
--- a/image_transport/include/image_transport/raw_subscriber.hpp
+++ b/image_transport/include/image_transport/raw_subscriber.hpp
@@ -53,20 +53,31 @@ class RawSubscriber : public SimpleSubscriberPlugin<sensor_msgs::msg::Image>
 public:
   virtual ~RawSubscriber() {}
 
-  virtual std::string getTransportName() const
+  std::string getTransportName() const override
   {
     return "raw";
   }
 
 protected:
-  virtual void internalCallback(const std::shared_ptr<const sensor_msgs::msg::Image>& message, const Callback& user_cb)
+  void internalCallback(
+    const std::shared_ptr<const sensor_msgs::msg::Image>& message, const Callback& user_cb) override
   {
     user_cb(message);
   }
 
-  virtual std::string getTopicToSubscribe(const std::string& base_topic) const
+  std::string getTopicToSubscribe(const std::string& base_topic) const override
   {
     return base_topic;
+  }
+
+  void subscribeImpl(
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    const Callback & callback,
+    rmw_qos_profile_t custom_qos,
+    rclcpp::SubscriptionOptions options) override
+  {
+    this->subscribeImplWithOptions(node, base_topic, callback, custom_qos, options);
   }
 };
 

--- a/image_transport/include/image_transport/simple_subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/simple_subscriber_plugin.hpp
@@ -118,9 +118,12 @@ protected:
     const Callback & callback,
     rmw_qos_profile_t custom_qos) override
   {
+    impl_ = std::make_unique<Impl>();
+    // Push each group of transport-specific parameters into a separate sub-namespace
+    //ros::NodeHandle param_nh(transport_hints.getParameterNH(), getTransportName());
+    //
     auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
-    auto topic_to_subscribe = getTopicToSubscribe(base_topic);
-    impl_->sub_ = node->create_subscription<M>(topic_to_subscribe, qos,
+    impl_->sub_ = node->create_subscription<M>(getTopicToSubscribe(base_topic), qos,
         [this, callback](const typename std::shared_ptr<const M> msg){
           internalCallback(msg, callback);
         });
@@ -132,7 +135,7 @@ private:
     rclcpp::SubscriptionBase::SharedPtr sub_;
   };
 
-  std::unique_ptr<Impl> impl_ = std::make_unique<Impl>();
+  std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace image_transport

--- a/image_transport/include/image_transport/simple_subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/simple_subscriber_plugin.hpp
@@ -118,25 +118,12 @@ protected:
     const Callback & callback,
     rmw_qos_profile_t custom_qos) override
   {
-    this->subscribeImpl(node, base_topic, callback, custom_qos, rclcpp::SubscriptionOptions());
-  }
-
-  void subscribeImpl(
-    rclcpp::Node * node,
-    const std::string & base_topic,
-    const Callback & callback,
-    rmw_qos_profile_t custom_qos,
-    rclcpp::SubscriptionOptions options) override
-  {
-    impl_ = std::make_unique<Impl>();
-    // Push each group of transport-specific parameters into a separate sub-namespace
-    //ros::NodeHandle param_nh(transport_hints.getParameterNH(), getTransportName());
-    //
     auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
-    impl_->sub_ = node->create_subscription<M>(getTopicToSubscribe(base_topic), qos,
+    auto topic_to_subscribe = getTopicToSubscribe(base_topic);
+    impl_->sub_ = node->create_subscription<M>(topic_to_subscribe, qos,
         [this, callback](const typename std::shared_ptr<const M> msg){
           internalCallback(msg, callback);
-        }, options);
+        });
   }
 
 private:
@@ -145,10 +132,7 @@ private:
     rclcpp::SubscriptionBase::SharedPtr sub_;
   };
 
-  std::unique_ptr<Impl> impl_;
-
-
-
+  std::unique_ptr<Impl> impl_ = std::make_unique<Impl>();
 };
 
 }  // namespace image_transport

--- a/image_transport/include/image_transport/simple_subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/simple_subscriber_plugin.hpp
@@ -112,7 +112,7 @@ protected:
     return base_topic + "/" + getTransportName();
   }
 
-  virtual void subscribeImpl(
+  void subscribeImpl(
     rclcpp::Node * node,
     const std::string & base_topic,
     const Callback & callback,
@@ -127,6 +127,25 @@ protected:
         [this, callback](const typename std::shared_ptr<const M> msg){
           internalCallback(msg, callback);
         });
+  }
+
+  void subscribeImplWithOptions(
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    const Callback & callback,
+    rmw_qos_profile_t custom_qos,
+    rclcpp::SubscriptionOptions options)
+  {
+    impl_ = std::make_unique<Impl>();
+    // Push each group of transport-specific parameters into a separate sub-namespace
+    //ros::NodeHandle param_nh(transport_hints.getParameterNH(), getTransportName());
+    //
+    auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
+    impl_->sub_ = node->create_subscription<M>(getTopicToSubscribe(base_topic), qos,
+        [this, callback](const typename std::shared_ptr<const M> msg){
+          internalCallback(msg, callback);
+        },
+        options);
   }
 
 private:

--- a/image_transport/include/image_transport/subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/subscriber_plugin.hpp
@@ -164,7 +164,7 @@ protected:
       node->get_logger(),
       "SubscriberPlugin::subscribeImpl with five arguments has not been overridden");
     this->subscribeImpl(node, base_topic, callback, custom_qos);
-    }
+  }
 };
 
 }  // namespace image_transport

--- a/image_transport/tutorial/include/image_transport_tutorial/resized_subscriber.hpp
+++ b/image_transport/tutorial/include/image_transport_tutorial/resized_subscriber.hpp
@@ -11,6 +11,15 @@ public:
     return "resized";
   }
 
+  void subscribeImpl(
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    const Callback & callback,
+    rmw_qos_profile_t custom_qos,
+    rclcpp::SubscriptionOptions options) override
+  {
+    this->subscribeImplWithOptions(node, base_topic, callback, custom_qos, options);
+  }
 protected:
   virtual void internalCallback(const typename image_transport_tutorial::ResizedImage::ConstPtr& message,
                                 const Callback& user_cb);


### PR DESCRIPTION
* Do not override the subscribeImpl method taking a rclcpp::SubscriptionOptions object.
  Plugins that were not overriding it before won't notice that they have to be update.

That was done in https://github.com/ros-perception/image_common/pull/186.
To be more clear, the issue is that external plugins are usually inheriting from `SimpleSubscriberPlugin` and not from `SubscriberPlugin`.
e.g. [this method](https://github.com/ros-perception/image_transport_plugins/blob/7cedbf04d5deb3b183d92756b912816ce7618aca/compressed_image_transport/src/compressed_subscriber.cpp#L60) was not called anymore after that patch, resulting in the compressed image transport subscriber plugin not being correctly initialized.