### PR TITLE
👩‍🌾 [ros2] Fix clang warning about hidden overloads

### DIFF
--- a/image_transport/include/image_transport/raw_subscriber.hpp
+++ b/image_transport/include/image_transport/raw_subscriber.hpp
@@ -70,6 +70,8 @@ protected:
     return base_topic;
   }
 
+  using SubscriberPlugin::subscribeImpl;
+
   void subscribeImpl(
     rclcpp::Node * node,
     const std::string & base_topic,


### PR DESCRIPTION
Clang is overly cautions about virtual overloads. After https://github.com/ros-perception/image_common/pull/195 was merged, we started getting this warning in the [macOS nightlies](https://ci.ros2.org/view/nightly/job/nightly_osx_release/2106/consoleFull):

```
01:56:54 In file included from /Users/osrf/jenkins-agent/workspace/nightly_osx_release/ws/src/ros-perception/image_common/image_transport/src/manifest.cpp:38:
01:56:54 /Users/osrf/jenkins-agent/workspace/nightly_osx_release/ws/src/ros-perception/image_common/image_transport/include/image_transport/raw_subscriber.hpp:73:8: warning: 'image_transport::RawSubscriber::subscribeImpl' hides overloaded virtual function [-Woverloaded-virtual]
01:56:54   void subscribeImpl(
01:56:54        ^
01:56:54 /Users/osrf/jenkins-agent/workspace/nightly_osx_release/ws/src/ros-perception/image_common/image_transport/include/image_transport/simple_subscriber_plugin.hpp:115:8: note: hidden overloaded virtual function 'image_transport::SimpleSubscriberPlugin<sensor_msgs::msg::Image_<std::__1::allocator<void> > >::subscribeImpl' declared here: different number of parameters (4 vs 5)
01:56:54   void subscribeImpl(
01:56:54        ^
01:56:54 1 warning generated.
```

I tested locally on Ubuntu Focal with clang 10 that adding this line gives clang some peace of mind.

---

https://github.com/osrf/buildfarmer/issues/207

