### PR TITLE
fix compiler warnings due to extra ";" after end of namespace braces

### DIFF
--- a/camera_info_manager/include/camera_info_manager/camera_info_manager.h
+++ b/camera_info_manager/include/camera_info_manager/camera_info_manager.h
@@ -252,6 +252,6 @@ class CAMERA_INFO_MANAGER_DECL CameraInfoManager
 
 }; // class CameraInfoManager
 
-}; // namespace camera_info_manager
+} // namespace camera_info_manager
 
 #endif // _CAMERA_INFO_MANAGER_H_


### PR DESCRIPTION
When I compile with "-Wpedantic" I get the below warnings due to the extra ";" in the camera_info_manager header file.
This PR fixes the warning.

```
/opt/ros/noetic/include/camera_info_manager/camera_info_manager.h:255:2: warning: extra ‘;’ [-Wpedantic]                                                                                                           
  255 | }; // namespace camera_info_manager           
```     