### PR TITLE
Fix renamed `rcpputils` header

### DIFF
--- a/camera_info_manager/src/camera_info_manager.cpp
+++ b/camera_info_manager/src/camera_info_manager.cpp
@@ -43,7 +43,7 @@
 #include <string>
 
 #include "rcpputils/filesystem_helper.hpp"
-#include "rcpputils/get_env.hpp"
+#include "rcpputils/env.hpp"
 #include "camera_calibration_parsers/parse.hpp"
 #include "ament_index_cpp/get_package_share_directory.hpp"
 


### PR DESCRIPTION
`rcpputils/get_env.hpp` is renamed to `rcpputils/env.hpp` as part of https://github.com/ros2/rcpputils/pull/150, so the corresponding includes have been fixed in this PR.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>