### PR TITLE
Export a modern CMake target instead of variables and install includes to include/${PROJECT_NAME}

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -61,7 +61,9 @@ ament_export_targets(export_${PROJECT_NAME})
 
 # define the exe to convert
 add_executable(convert src/convert.cpp)
-target_link_libraries(convert ${PROJECT_NAME})
+target_link_libraries(convert
+  ${PROJECT_NAME}
+  rclcpp::rclcpp)
 
 install(
   TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}

--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -25,13 +25,15 @@ add_library(${PROJECT_NAME}
   src/parse_yml.cpp
 )
 target_link_libraries(${PROJECT_NAME} PUBLIC
-  rclcpp::rclcpp
-  rcpputils::rcpputils
   ${sensor_msgs_TARGETS}
   ${yaml_cpp_vendor_TARGETS})
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  rclcpp::rclcpp
+  rcpputils::rcpputils)
+
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE "CAMERA_CALIBRATION_PARSERS_BUILDING_DLL")
 
@@ -75,11 +77,10 @@ install(
 
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 
 ament_export_dependencies(rclcpp rcpputils sensor_msgs yaml_cpp_vendor)
-
 
 if(BUILD_TESTING)
   #TODO(mjcarroll) switch back to this once I can fix copyright check

--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -18,28 +18,28 @@ find_package(rcpputils REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 
-include_directories(include)
-
 # define the library
 add_library(${PROJECT_NAME}
   src/parse.cpp
   src/parse_ini.cpp
   src/parse_yml.cpp
 )
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rclcpp::rclcpp
+  rcpputils::rcpputils
+  ${sensor_msgs_TARGETS}
+  ${yaml_cpp_vendor_TARGETS})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE "CAMERA_CALIBRATION_PARSERS_BUILDING_DLL")
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-  target_link_libraries(${PROJECT_NAME} stdc++fs)
+  target_link_libraries(${PROJECT_NAME} PUBLIC stdc++fs)
 endif()
 
-ament_target_dependencies(
-  ${PROJECT_NAME}
-  rclcpp
-  rcpputils
-  sensor_msgs
-  yaml_cpp_vendor
-)
+ament_export_targets(export_${PROJECT_NAME})
 
 # TODO: Reenable Python Wrapper with new serialization technique.
 #find_package(PythonLibs REQUIRED)
@@ -62,7 +62,7 @@ add_executable(convert src/convert.cpp)
 target_link_libraries(convert ${PROJECT_NAME})
 
 install(
-  TARGETS ${PROJECT_NAME}
+  TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -78,8 +78,6 @@ install(
   DESTINATION include
 )
 
-ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(rclcpp rcpputils sensor_msgs yaml_cpp_vendor)
 
 

--- a/camera_info_manager/CMakeLists.txt
+++ b/camera_info_manager/CMakeLists.txt
@@ -23,37 +23,32 @@ find_package(rclcpp REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-include_directories(include)
-
 # add a library
 add_library(${PROJECT_NAME} src/camera_info_manager.cpp)
-
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 target_compile_definitions(${PROJECT_NAME} PRIVATE "CAMERA_INFO_MANAGER_BUILDING_DLL")
-
-ament_target_dependencies(
-  ${PROJECT_NAME}
-  ament_index_cpp
-  camera_calibration_parsers
-  rclcpp
-  rcpputils
-  sensor_msgs
-)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rclcpp::rclcpp
+  ${sensor_msgs_TARGETS})
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  ament_index_cpp::ament_index_cpp
+  camera_calibration_parser::camera_calibration_parsers
+  rcpputils::rcpputils)
 
 install(
   TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
-install(
-  DIRECTORY include/
-  DESTINATION include
-)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
-ament_export_include_directories(include)
 ament_export_dependencies(ament_index_cpp camera_calibration_parsers rclcpp rcpputils sensor_msgs)
-ament_export_libraries(${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 
 if(BUILD_TESTING)
   #TODO(mjcarroll) switch back to this once I can fix copyright check

--- a/camera_info_manager/CMakeLists.txt
+++ b/camera_info_manager/CMakeLists.txt
@@ -27,7 +27,7 @@ find_package(sensor_msgs REQUIRED)
 add_library(${PROJECT_NAME} src/camera_info_manager.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_compile_definitions(${PROJECT_NAME} PRIVATE "CAMERA_INFO_MANAGER_BUILDING_DLL")
 target_link_libraries(${PROJECT_NAME} PUBLIC
   rclcpp::rclcpp

--- a/camera_info_manager/CMakeLists.txt
+++ b/camera_info_manager/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   ${sensor_msgs_TARGETS})
 target_link_libraries(${PROJECT_NAME} PRIVATE
   ament_index_cpp::ament_index_cpp
-  camera_calibration_parser::camera_calibration_parsers
+  camera_calibration_parsers::camera_calibration_parsers
   rcpputils::rcpputils)
 
 install(

--- a/image_transport/CMakeLists.txt
+++ b/image_transport/CMakeLists.txt
@@ -51,7 +51,9 @@ target_link_libraries(${PROJECT_NAME}_plugins PRIVATE
 
 # Build list_transports
 add_executable(list_transports src/list_transports.cpp)
-target_link_libraries(list_transports ${PROJECT_NAME})
+target_link_libraries(list_transports
+  ${PROJECT_NAME}
+  pluginlib::pluginlib)
 
 # Build republish
 add_executable(republish src/republish.cpp)

--- a/image_transport/CMakeLists.txt
+++ b/image_transport/CMakeLists.txt
@@ -78,7 +78,7 @@ install(
 # Install include directories
 install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
-ament_export_targets(export${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
 
 ament_export_dependencies(message_filters rclcpp sensor_msgs pluginlib)
 

--- a/image_transport/CMakeLists.txt
+++ b/image_transport/CMakeLists.txt
@@ -18,8 +18,6 @@ find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-include_directories(include)
-
 # Build image_transport library
 add_library(${PROJECT_NAME}
   src/camera_common.cpp
@@ -30,14 +28,15 @@ add_library(${PROJECT_NAME}
   src/camera_subscriber.cpp
   src/image_transport.cpp
 )
-
-ament_target_dependencies(
-  ${PROJECT_NAME}
-  message_filters
-  pluginlib
-  rclcpp
-  sensor_msgs
-)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  message_filters::message_filters
+  rclcpp::rclcpp
+  ${sensor_msgs_TARGETS})
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  pluginlib::pluginlin)
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 target_compile_definitions(${PROJECT_NAME} PRIVATE "IMAGE_TRANSPORT_BUILDING_DLL")
@@ -47,6 +46,8 @@ add_library(${PROJECT_NAME}_plugins
   src/manifest.cpp
 )
 target_link_libraries(${PROJECT_NAME}_plugins ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME}_plugins PRIVATE
+  pluginlib::pluginlin)
 
 # Build list_transports
 add_executable(list_transports src/list_transports.cpp)
@@ -66,6 +67,7 @@ install(
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
+install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME})
 
 # Install executables
 install(
@@ -74,13 +76,9 @@ install(
 )
 
 # Install include directories
-install(
-  DIRECTORY include/
-  DESTINATION include
-)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME)
 
-ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
+ament_export_targets(export${PROJECT_NAME})
 
 ament_export_dependencies(message_filters rclcpp sensor_msgs pluginlib)
 

--- a/image_transport/CMakeLists.txt
+++ b/image_transport/CMakeLists.txt
@@ -55,7 +55,9 @@ target_link_libraries(list_transports ${PROJECT_NAME})
 
 # Build republish
 add_executable(republish src/republish.cpp)
-target_link_libraries(republish ${PROJECT_NAME})
+target_link_libraries(republish
+  ${PROJECT_NAME}
+  pluginlib::pluginlib)
 
 # Install plugin descriptions
 pluginlib_export_plugin_description_file(image_transport default_plugins.xml)

--- a/image_transport/CMakeLists.txt
+++ b/image_transport/CMakeLists.txt
@@ -45,8 +45,8 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "IMAGE_TRANSPORT_BUILDING_DLL
 add_library(${PROJECT_NAME}_plugins
   src/manifest.cpp
 )
-target_link_libraries(${PROJECT_NAME}_plugins ${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME}_plugins PRIVATE
+  ${PROJECT_NAME}
   pluginlib::pluginlin)
 
 # Build list_transports
@@ -76,7 +76,7 @@ install(
 )
 
 # Install include directories
-install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 ament_export_targets(export${PROJECT_NAME})
 

--- a/image_transport/CMakeLists.txt
+++ b/image_transport/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(${PROJECT_NAME}_plugins
 )
 target_link_libraries(${PROJECT_NAME}_plugins PRIVATE
   ${PROJECT_NAME}
-  pluginlib::pluginlin)
+  pluginlib::pluginlib)
 
 # Build list_transports
 add_executable(list_transports src/list_transports.cpp)

--- a/image_transport/CMakeLists.txt
+++ b/image_transport/CMakeLists.txt
@@ -36,7 +36,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   rclcpp::rclcpp
   ${sensor_msgs_TARGETS})
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  pluginlib::pluginlin)
+  pluginlib::pluginlib)
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 target_compile_definitions(${PROJECT_NAME} PRIVATE "IMAGE_TRANSPORT_BUILDING_DLL")


### PR DESCRIPTION
Part of ament/ament_cmake#365
Part of ament/ament_cmake#292
Part of ros2/ros2#1150

This makes `camera_calibration_parsers` export a modern CMake target instead of old-style variables. It also makes it install includes to `include/${PROJECT_NAME}` to mitigate include directory search order issues when overriding packages.