### PR TITLE
Fix build issue when compiling with custom boost version

### DIFF
--- a/image_transport/CMakeLists.txt
+++ b/image_transport/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED
     sensor_msgs
 )
 
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED COMPONENTS filesystem)
 
 catkin_package(
   INCLUDE_DIRS include


### PR DESCRIPTION
Hello,

Recently I received this linking error when compiling `image_common` from source. I was able to fix this by defining the components that need to be linked (in this case filesystem) in the `CMakeList.txt`

System Info:
Operating System: Ubuntu 20.04
Boost Version 1.78
Python Version 3.10

```
[ 48%] Linking CXX executable /opt/arc/ros_ws/devel/lib/image_transport/list_transports
[ 51%] Linking CXX executable /opt/arc/ros_ws/devel/lib/image_transport/republish
/usr/bin/ld: CMakeFiles/list_transports.dir/src/list_transports.cpp.o: in function `boost::filesystem::path::parent_path() const':
list_transports.cpp:(.text._ZNK5boost10filesystem4path11parent_pathEv[_ZNK5boost10filesystem4path11parent_pathEv]+0x2c): undefined reference to `boost::filesystem::path::find_parent_path_size() const'
/usr/bin/ld: CMakeFiles/list_transports.dir/src/list_transports.cpp.o: in function `boost::filesystem::operator/(boost::filesystem::path const&, boost::filesystem::path const&)':
list_transports.cpp:(.text._ZN5boost10filesystemdvERKNS0_4pathES3_[_ZN5boost10filesystemdvERKNS0_4pathES3_]+0x6a): undefined reference to `boost::filesystem::path::append_v3(boost::filesystem::path const&)'
/usr/bin/ld: CMakeFiles/list_transports.dir/src/list_transports.cpp.o: in function `pluginlib::ClassLoader<image_transport::PublisherPlugin>::getPackageFromPluginXMLFilePath(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
list_transports.cpp:(.text._ZN9pluginlib11ClassLoaderIN15image_transport15PublisherPluginEE31getPackageFromPluginXMLFilePathERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN9pluginlib11ClassLoaderIN15image_transport15PublisherPluginEE31getPackageFromPluginXMLFilePathERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x1cf): undefined reference to `boost::filesystem::path::filename_v3() const'
/usr/bin/ld: CMakeFiles/list_transports.dir/src/list_transports.cpp.o: in function `pluginlib::ClassLoader<image_transport::SubscriberPlugin>::getPackageFromPluginXMLFilePath(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
list_transports.cpp:(.text._ZN9pluginlib11ClassLoaderIN15image_transport16SubscriberPluginEE31getPackageFromPluginXMLFilePathERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN9pluginlib11ClassLoaderIN15image_transport16SubscriberPluginEE31getPackageFromPluginXMLFilePathERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x1cf): undefined reference to `boost::filesystem::path::filename_v3() const'
collect2: error: ld returned 1 exit status
make[2]: *** [image_common/image_transport/CMakeFiles/list_transports.dir/build.make:111: /opt/arc/ros_ws/devel/lib/image_transport/list_transports] Error 1
make[1]: *** [CMakeFiles/Makefile2:2738: image_common/image_transport/CMakeFiles/list_transports.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
/usr/bin/ld: CMakeFiles/republish.dir/src/republish.cpp.o: in function `boost::filesystem::path::parent_path() const':
republish.cpp:(.text._ZNK5boost10filesystem4path11parent_pathEv[_ZNK5boost10filesystem4path11parent_pathEv]+0x2c): undefined reference to `boost::filesystem::path::find_parent_path_size() const'
/usr/bin/ld: CMakeFiles/republish.dir/src/republish.cpp.o: in function `boost::filesystem::operator/(boost::filesystem::path const&, boost::filesystem::path const&)':
republish.cpp:(.text._ZN5boost10filesystemdvERKNS0_4pathES3_[_ZN5boost10filesystemdvERKNS0_4pathES3_]+0x6a): undefined reference to `boost::filesystem::path::append_v3(boost::filesystem::path const&)'
/usr/bin/ld: CMakeFiles/republish.dir/src/republish.cpp.o: in function `pluginlib::ClassLoader<image_transport::PublisherPlugin>::getPackageFromPluginXMLFilePath(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
republish.cpp:(.text._ZN9pluginlib11ClassLoaderIN15image_transport15PublisherPluginEE31getPackageFromPluginXMLFilePathERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE[_ZN9pluginlib11ClassLoaderIN15image_transport15PublisherPluginEE31getPackageFromPluginXMLFilePathERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE]+0x1cf): undefined reference to `boost::filesystem::path::filename_v3() const'
collect2: error: ld returned 1 exit status
make[2]: *** [image_common/image_transport/CMakeFiles/republish.dir/build.make:111: /opt/arc/ros_ws/devel/lib/image_transport/republish] Error 1
make[1]: *** [CMakeFiles/Makefile2:2765: image_common/image_transport/CMakeFiles/republish.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```