### PR TITLE
Remove PLUGINLIB__DISABLE_BOOST_FUNCTIONS definition.

### DIFF
--- a/image_transport/CMakeLists.txt
+++ b/image_transport/CMakeLists.txt
@@ -38,7 +38,6 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
 target_link_libraries(${PROJECT_NAME} PRIVATE
   pluginlib::pluginlib)
 
-target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 target_compile_definitions(${PROJECT_NAME} PRIVATE "IMAGE_TRANSPORT_BUILDING_DLL")
 
 # Build image_transport_plugins library (raw)


### PR DESCRIPTION
This hasn't been required in almost 2 years now.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>