### PR TITLE
[Backport/Galactic] Simple IT plugins shutdown

### DIFF
--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -97,7 +97,7 @@ public:
 
   virtual void shutdown()
   {
-    //if (simple_impl_) simple_impl_->pub_.shutdown();
+    simple_impl_.reset();
   }
 
 protected:

--- a/image_transport/include/image_transport/simple_subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/simple_subscriber_plugin.hpp
@@ -86,8 +86,7 @@ public:
 
   virtual void shutdown()
   {
-    // TODO(ros2) Enable shutdown when rcl/rmw supports it.
-    //if (simple_impl_) simple_impl_->sub_.shutdown();
+    impl_.reset();
   }
 
 protected:

--- a/image_transport/test/test_publisher.cpp
+++ b/image_transport/test/test_publisher.cpp
@@ -36,8 +36,15 @@ TEST_F(TestPublisher, ImageTransportCameraPublisher) {
   auto pub = it.advertiseCamera("camera/image", 1);
 }
 
+TEST_F(TestPublisher, Shutdown) {
+  auto pub = image_transport::create_publisher(node_.get(), "camera/image");
+  EXPECT_EQ(node_->get_node_graph_interface()->count_publishers("camera/image"), 1u);
+  pub.shutdown();
+  EXPECT_EQ(node_->get_node_graph_interface()->count_publishers("camera/image"), 0u);
+}
 
-int main(int argc, char** argv) {
+int main(int argc, char ** argv)
+{
   rclcpp::init(argc, argv);
   testing::InitGoogleTest(&argc, argv);
   int ret = RUN_ALL_TESTS();

--- a/image_transport/test/test_subscriber.cpp
+++ b/image_transport/test/test_subscriber.cpp
@@ -28,7 +28,18 @@ TEST_F(TestPublisher, construction_and_destruction) {
   executor.spin_node_some(node_);
 }
 
-int main(int argc, char** argv) {
+TEST_F(TestPublisher, shutdown) {
+  std::function<void(const sensor_msgs::msg::Image::ConstSharedPtr & msg)> fcn =
+    [](const auto & msg) {(void)msg;};
+
+  auto sub = image_transport::create_subscription(node_.get(), "camera/image", fcn, "raw");
+  EXPECT_EQ(node_->get_node_graph_interface()->count_subscribers("camera/image"), 1u);
+  sub.shutdown();
+  EXPECT_EQ(node_->get_node_graph_interface()->count_subscribers("camera/image"), 0u);
+}
+
+int main(int argc, char ** argv)
+{
   rclcpp::init(argc, argv);
   testing::InitGoogleTest(&argc, argv);
   int ret = RUN_ALL_TESTS();


### PR DESCRIPTION
* implemented shutdown() for simple publisher and subscriber plugin

* added tests for simple publisher/subscriber shutdown

* Removed unneeded lines in publisher shutdown test

Co-authored-by: Matej Vargovcik <vargovcik@robotechvision.com>