### PR TITLE
Remove YAML_CPP_DLL define

### DIFF
--- a/camera_calibration_parsers/src/parse_yml.cpp
+++ b/camera_calibration_parsers/src/parse_yml.cpp
@@ -46,7 +46,6 @@
 #include "sensor_msgs/distortion_models.hpp"
 
 #ifdef _WIN32
-#define YAML_CPP_DLL
 // TODO(mjcarroll): This shouldn't be needed, but there are some issues
 // with MSVC and YAML-CPP that are upstream causing warnings in CI.
 #pragma warning(push)


### PR DESCRIPTION
Since https://github.com/ros2/yaml_cpp_vendor/issues/10 is fixed, the explicit `YAML_CPP_DLL` define is no longer needed and needs to be removed to prevent the macro redefinition warnings.

This should be backported to foxy and galactic.