### PR TITLE
Tests depend on rcpputils

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -102,12 +102,12 @@ if(BUILD_TESTING)
 
   ament_add_gtest(${PROJECT_NAME}-parse_ini test/test_parse_ini.cpp)
   if(TARGET ${PROJECT_NAME}-parse_ini)
-    target_link_libraries(${PROJECT_NAME}-parse_ini ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}-parse_ini ${PROJECT_NAME} rcpputils::rcpputils)
   endif()
 
   ament_add_gtest(${PROJECT_NAME}-parse_yml test/test_parse_yml.cpp)
   if(TARGET ${PROJECT_NAME}-parse_yml)
-    target_link_libraries(${PROJECT_NAME}-parse_yml ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}-parse_yml ${PROJECT_NAME} rcpputils::rcpputils)
   endif()
 endif()
 


### PR DESCRIPTION
Used here:

https://github.com/ros-perception/image_common/blob/ca09c1c80cf3db350e273eca83878c29b2af8bbd/camera_calibration_parsers/test/test_parse_ini.cpp#L21

https://github.com/ros-perception/image_common/blob/ca09c1c80cf3db350e273eca83878c29b2af8bbd/camera_calibration_parsers/test/test_parse_yml.cpp#L22