### PR TITLE
[ADD] std::optional for PublisherOptions

### DIFF
--- a/image_transport/include/image_transport/image_transport.hpp
+++ b/image_transport/include/image_transport/image_transport.hpp
@@ -54,7 +54,7 @@ Publisher create_publisher(
   rclcpp::Node * node,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
-  rclcpp::PublisherOptions options = rclcpp::PublisherOptions());
+  std::optional<rclcpp::PublisherOptions> options = {});
 
 /**
  * \brief Subscribe to an image topic, free function version.

--- a/image_transport/include/image_transport/publisher.hpp
+++ b/image_transport/include/image_transport/publisher.hpp
@@ -74,7 +74,7 @@ public:
     const std::string & base_topic,
     PubLoaderPtr loader,
     rmw_qos_profile_t custom_qos,
-    rclcpp::PublisherOptions options = rclcpp::PublisherOptions());
+    std::optional<rclcpp::PublisherOptions> options = {});
 
   /*!
    * \brief Returns the number of subscribers that are currently connected to

--- a/image_transport/include/image_transport/publisher_plugin.hpp
+++ b/image_transport/include/image_transport/publisher_plugin.hpp
@@ -66,9 +66,16 @@ public:
     rclcpp::Node * nh,
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
-    rclcpp::PublisherOptions options = rclcpp::PublisherOptions())
+    std::optional<rclcpp::PublisherOptions> options = {})
   {
-    advertiseImpl(nh, base_topic, custom_qos, options);
+    if (options)
+    {
+      advertiseImpl(nh, base_topic, custom_qos, *options);
+    }
+    else
+    {
+      advertiseImpl(nh, base_topic, custom_qos);
+    }
   }
 
   /**

--- a/image_transport/include/image_transport/raw_publisher.hpp
+++ b/image_transport/include/image_transport/raw_publisher.hpp
@@ -73,7 +73,7 @@ protected:
     rmw_qos_profile_t custom_qos,
     rclcpp::PublisherOptions options) override
   {
-    this->advertiseImplWithOptions(node, base_topic, custom_qos, options);
+    this->advertiseImpl(node, base_topic, custom_qos, options);
   }
 };
 

--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -110,11 +110,11 @@ protected:
     simple_impl_->pub_ = node->create_publisher<M>(transport_topic, qos);
   }
 
-  void advertiseImplWithOptions(
+  void advertiseImpl(
     rclcpp::Node * node,
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos,
-    rclcpp::PublisherOptions options)
+    rclcpp::PublisherOptions options) override
   {
     std::string transport_topic = getTopicToAdvertise(base_topic);
     simple_impl_ = std::make_unique<SimplePublisherPluginImpl>(node);

--- a/image_transport/src/image_transport.cpp
+++ b/image_transport/src/image_transport.cpp
@@ -60,7 +60,7 @@ Publisher create_publisher(
   rclcpp::Node * node,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos,
-  rclcpp::PublisherOptions options)
+  std::optional<rclcpp::PublisherOptions> options)
 {
   return Publisher(node, base_topic, kImpl->pub_loader_, custom_qos, options);
 }

--- a/image_transport/src/publisher.cpp
+++ b/image_transport/src/publisher.cpp
@@ -99,7 +99,7 @@ struct Publisher::Impl
 Publisher::Publisher(
   rclcpp::Node * node, const std::string & base_topic,
   PubLoaderPtr loader, rmw_qos_profile_t custom_qos,
-  rclcpp::PublisherOptions options)
+  std::optional<rclcpp::PublisherOptions> options)
 : impl_(std::make_shared<Impl>(node))
 {
   // Resolve the name explicitly because otherwise the compressed topics don't remap


### PR DESCRIPTION
as described in this https://github.com/ros-perception/image_common/issues/240 `PublisherOptions` are optional when advertising a topic.
By this, the correct `advertiseImpl` function is called automatically avoiding error messages.

Additionally, `advertiseImplWithOptions` was renamed to override the respective parent class function instead of creating a new function which also caused error messages due to the missing child class implementation.