### PR TITLE
[FIX] function name

### DIFF
--- a/image_transport/include/image_transport/raw_publisher.hpp
+++ b/image_transport/include/image_transport/raw_publisher.hpp
@@ -73,7 +73,7 @@ protected:
     rmw_qos_profile_t custom_qos,
     rclcpp::PublisherOptions options) override
   {
-    this->advertiseImplWithOptions(node, base_topic, custom_qos, options);
+    this->advertiseImpl(node, base_topic, custom_qos, options);
   }
 };
 

--- a/image_transport/include/image_transport/raw_publisher.hpp
+++ b/image_transport/include/image_transport/raw_publisher.hpp
@@ -49,6 +49,8 @@ namespace image_transport
 class RawPublisher : public SimplePublisherPlugin<sensor_msgs::msg::Image>
 {
 public:
+  using Base = SimplePublisherPlugin<sensor_msgs::msg::Image>;
+
   virtual ~RawPublisher() {}
 
   virtual std::string getTransportName() const
@@ -73,7 +75,7 @@ protected:
     rmw_qos_profile_t custom_qos,
     rclcpp::PublisherOptions options) override
   {
-    this->advertiseImpl(node, base_topic, custom_qos, options);
+    Base::advertiseImpl(node, base_topic, custom_qos, options);
   }
 };
 

--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -110,11 +110,11 @@ protected:
     simple_impl_->pub_ = node->create_publisher<M>(transport_topic, qos);
   }
 
-  void advertiseImplWithOptions(
+  void advertiseImpl(
     rclcpp::Node * node,
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos,
-    rclcpp::PublisherOptions options)
+    rclcpp::PublisherOptions options) override
   {
     std::string transport_topic = getTopicToAdvertise(base_topic);
     simple_impl_ = std::make_unique<SimplePublisherPluginImpl>(node);


### PR DESCRIPTION
as mentioned in https://github.com/ros-perception/image_common/issues/240 a function name is updated to override a parent function and, thus, issues are avoided when using plugins.