### PR TITLE
[ADD] std::optional for PublisherOptions

### DIFF
--- a/image_transport/include/image_transport/image_transport.hpp
+++ b/image_transport/include/image_transport/image_transport.hpp
@@ -54,7 +54,7 @@ Publisher create_publisher(
   rclcpp::Node * node,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
-  rclcpp::PublisherOptions options = rclcpp::PublisherOptions());
+  std::optional<rclcpp::PublisherOptions> options = {});
 
 /**
  * \brief Subscribe to an image topic, free function version.

--- a/image_transport/include/image_transport/publisher.hpp
+++ b/image_transport/include/image_transport/publisher.hpp
@@ -74,7 +74,7 @@ public:
     const std::string & base_topic,
     PubLoaderPtr loader,
     rmw_qos_profile_t custom_qos,
-    rclcpp::PublisherOptions options = rclcpp::PublisherOptions());
+    std::optional<rclcpp::PublisherOptions> options = {});
 
   /*!
    * \brief Returns the number of subscribers that are currently connected to

--- a/image_transport/include/image_transport/publisher_plugin.hpp
+++ b/image_transport/include/image_transport/publisher_plugin.hpp
@@ -66,9 +66,13 @@ public:
     rclcpp::Node * nh,
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
-    rclcpp::PublisherOptions options = rclcpp::PublisherOptions())
+    std::optional<rclcpp::PublisherOptions> options = {})
   {
-    advertiseImpl(nh, base_topic, custom_qos, options);
+    if (options) {
+      advertiseImpl(nh, base_topic, custom_qos, *options);
+    } else {
+      advertiseImpl(nh, base_topic, custom_qos);
+    }
   }
 
   /**

--- a/image_transport/include/image_transport/raw_publisher.hpp
+++ b/image_transport/include/image_transport/raw_publisher.hpp
@@ -48,6 +48,8 @@ namespace image_transport
 
 class RawPublisher : public SimplePublisherPlugin<sensor_msgs::msg::Image>
 {
+  using Base = SimplePublisherPlugin<sensor_msgs::msg::Image>;
+
 public:
   virtual ~RawPublisher() {}
 

--- a/image_transport/src/image_transport.cpp
+++ b/image_transport/src/image_transport.cpp
@@ -60,7 +60,7 @@ Publisher create_publisher(
   rclcpp::Node * node,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos,
-  rclcpp::PublisherOptions options)
+  std::optional<rclcpp::PublisherOptions> options)
 {
   return Publisher(node, base_topic, kImpl->pub_loader_, custom_qos, options);
 }

--- a/image_transport/src/publisher.cpp
+++ b/image_transport/src/publisher.cpp
@@ -99,7 +99,7 @@ struct Publisher::Impl
 Publisher::Publisher(
   rclcpp::Node * node, const std::string & base_topic,
   PubLoaderPtr loader, rmw_qos_profile_t custom_qos,
-  rclcpp::PublisherOptions options)
+  std::optional<rclcpp::PublisherOptions> options)
 : impl_(std::make_shared<Impl>(node))
 {
   // Resolve the name explicitly because otherwise the compressed topics don't remap


### PR DESCRIPTION
fixing https://github.com/ros-perception/image_common/issues/240 this PR uses `std::optionals` in order to allow advertising publishers without specifying `PublisherOptions`.
By this, the error message 
```
PublisherPlugin::advertiseImpl with four arguments has not been overridden
```
is avoided.
However, if PublisherOptions are specified, it still occurs.