### PR TITLE
Deprecate impl without options

### DIFF
--- a/image_transport/include/image_transport/publisher_plugin.hpp
+++ b/image_transport/include/image_transport/publisher_plugin.hpp
@@ -132,9 +132,11 @@ public:
 
 protected:
   /**
-   * \deprecated Use advertiseImpl with four parameters instead
+   * \deprecated Use advertiseImpl with four parameters instead by providing
+   * rclcpp::PublisherOptions as fourth argument.
    */
-  [[deprecated("Use advertiseImpl with four parameters instead")]]
+  [[deprecated("Use advertiseImpl with four parameters instead by providing "
+               "rclcpp::PublisherOptions as fourth argument.")]]
   virtual void advertiseImpl(
     rclcpp::Node * nh, const std::string & base_topic,
     rmw_qos_profile_t custom_qos)

--- a/image_transport/include/image_transport/publisher_plugin.hpp
+++ b/image_transport/include/image_transport/publisher_plugin.hpp
@@ -132,24 +132,24 @@ public:
 
 protected:
   /**
-   * \brief Advertise a topic. Must be implemented by the subclass.
+   * \deprecated Use advertiseImpl with four parameters instead
    */
+  [[deprecated("Use advertiseImpl with four parameters instead")]]
   virtual void advertiseImpl(
     rclcpp::Node * nh, const std::string & base_topic,
-    rmw_qos_profile_t custom_qos) = 0;
+    rmw_qos_profile_t custom_qos)
+  {
+    advertiseImpl(nh, base_topic, custom_qos, rclcpp::PublisherOptions());
+  }
 
+  /**
+   * \brief Advertise a topic. Must be implemented by the subclass.
+   */
   virtual void advertiseImpl(
     rclcpp::Node * node,
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos,
-    rclcpp::PublisherOptions options)
-  {
-    (void) options;
-    RCLCPP_ERROR(
-      node->get_logger(),
-      "PublisherPlugin::advertiseImpl with four arguments has not been overridden");
-    this->advertiseImpl(node, base_topic, custom_qos);
-  }
+    rclcpp::PublisherOptions options) = 0;
 };
 
 }  // namespace image_transport

--- a/image_transport/include/image_transport/publisher_plugin.hpp
+++ b/image_transport/include/image_transport/publisher_plugin.hpp
@@ -132,6 +132,15 @@ public:
 
 protected:
   /**
+   * \brief Advertise a topic. Must be implemented by the subclass.
+   */
+  virtual void advertiseImpl(
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    rmw_qos_profile_t custom_qos,
+    rclcpp::PublisherOptions options) = 0;
+
+  /**
    * \deprecated Use advertiseImpl with four parameters instead by providing
    * rclcpp::PublisherOptions as fourth argument.
    */
@@ -143,15 +152,6 @@ protected:
   {
     advertiseImpl(nh, base_topic, custom_qos, rclcpp::PublisherOptions());
   }
-
-  /**
-   * \brief Advertise a topic. Must be implemented by the subclass.
-   */
-  virtual void advertiseImpl(
-    rclcpp::Node * node,
-    const std::string & base_topic,
-    rmw_qos_profile_t custom_qos,
-    rclcpp::PublisherOptions options) = 0;
 };
 
 }  // namespace image_transport

--- a/image_transport/include/image_transport/raw_publisher.hpp
+++ b/image_transport/include/image_transport/raw_publisher.hpp
@@ -66,15 +66,6 @@ protected:
   {
     return base_topic;
   }
-
-  void advertiseImpl(
-    rclcpp::Node * node,
-    const std::string & base_topic,
-    rmw_qos_profile_t custom_qos,
-    rclcpp::PublisherOptions options) override
-  {
-    this->advertiseImplWithOptions(node, base_topic, custom_qos, options);
-  }
 };
 
 }  // namespace image_transport

--- a/image_transport/include/image_transport/raw_subscriber.hpp
+++ b/image_transport/include/image_transport/raw_subscriber.hpp
@@ -68,18 +68,6 @@ protected:
   {
     return base_topic;
   }
-
-  using SubscriberPlugin::subscribeImpl;
-
-  void subscribeImpl(
-    rclcpp::Node * node,
-    const std::string & base_topic,
-    const Callback & callback,
-    rmw_qos_profile_t custom_qos,
-    rclcpp::SubscriptionOptions options) override
-  {
-    this->subscribeImplWithOptions(node, base_topic, callback, custom_qos, options);
-  }
 };
 
 }  // namespace image_transport

--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -98,15 +98,6 @@ public:
   }
 
 protected:
-  [[deprecated("Use advertiseImpl with four parameters instead by providing "
-               "rclcpp::PublisherOptions as fourth argument.")]]
-  void advertiseImpl(
-    rclcpp::Node * node, const std::string & base_topic,
-    rmw_qos_profile_t custom_qos) override
-  {
-    advertiseImpl(node, base_topic, custom_qos, rclcpp::PublisherOptions{});
-  }
-
   void advertiseImpl(
     rclcpp::Node * node,
     const std::string & base_topic,
@@ -119,6 +110,25 @@ protected:
     RCLCPP_DEBUG(simple_impl_->logger_, "getTopicToAdvertise: %s", transport_topic.c_str());
     auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
     simple_impl_->pub_ = node->create_publisher<M>(transport_topic, qos, options);
+  }
+
+  [[deprecated("Use advertiseImpl with four parameters instead by providing "
+               "rclcpp::PublisherOptions as fourth argument.")]]
+  void advertiseImpl(
+    rclcpp::Node * node, const std::string & base_topic,
+    rmw_qos_profile_t custom_qos) override
+  {
+    advertiseImpl(node, base_topic, custom_qos, rclcpp::PublisherOptions{});
+  }
+
+  [[deprecated("Use advertiseImpl with four parameters instead.")]]
+  void advertiseImplWithOptions(
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    rmw_qos_profile_t custom_qos,
+    rclcpp::PublisherOptions options)
+  {
+    advertiseImpl(node, base_topic, custom_qos, options);
   }
 
   //! Generic function for publishing the internal message type.

--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -101,7 +101,7 @@ protected:
   [[deprecated("Use advertiseImpl with four parameters instead")]]
   void advertiseImpl(
     rclcpp::Node * node, const std::string & base_topic,
-    rmw_qos_profile_t custom_qos) override
+    rmw_qos_profile_t custom_qos) override final
   {
     advertiseImpl(node, base_topic, custom_qos, rclcpp::PublisherOptions{});
   }

--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -98,7 +98,8 @@ public:
   }
 
 protected:
-  [[deprecated("Use advertiseImpl with four parameters instead")]]
+  [[deprecated("Use advertiseImpl with four parameters instead by providing "
+               "rclcpp::PublisherOptions as fourth argument.")]]
   void advertiseImpl(
     rclcpp::Node * node, const std::string & base_topic,
     rmw_qos_profile_t custom_qos) override final

--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -98,23 +98,19 @@ public:
   }
 
 protected:
+  [[deprecated("Use advertiseImpl with four parameters instead")]]
   void advertiseImpl(
     rclcpp::Node * node, const std::string & base_topic,
     rmw_qos_profile_t custom_qos) override
   {
-    std::string transport_topic = getTopicToAdvertise(base_topic);
-    simple_impl_ = std::make_unique<SimplePublisherPluginImpl>(node);
-
-    RCLCPP_DEBUG(simple_impl_->logger_, "getTopicToAdvertise: %s", transport_topic.c_str());
-    auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
-    simple_impl_->pub_ = node->create_publisher<M>(transport_topic, qos);
+    advertiseImpl(node, base_topic, custom_qos, rclcpp::PublisherOptions{});
   }
 
-  void advertiseImplWithOptions(
+  void advertiseImpl(
     rclcpp::Node * node,
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos,
-    rclcpp::PublisherOptions options)
+    rclcpp::PublisherOptions options) override
   {
     std::string transport_topic = getTopicToAdvertise(base_topic);
     simple_impl_ = std::make_unique<SimplePublisherPluginImpl>(node);

--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -102,7 +102,7 @@ protected:
                "rclcpp::PublisherOptions as fourth argument.")]]
   void advertiseImpl(
     rclcpp::Node * node, const std::string & base_topic,
-    rmw_qos_profile_t custom_qos) override final
+    rmw_qos_profile_t custom_qos) override
   {
     advertiseImpl(node, base_topic, custom_qos, rclcpp::PublisherOptions{});
   }

--- a/image_transport/include/image_transport/simple_subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/simple_subscriber_plugin.hpp
@@ -112,26 +112,8 @@ protected:
     rclcpp::Node * node,
     const std::string & base_topic,
     const Callback & callback,
-    rmw_qos_profile_t custom_qos) override
-  {
-    impl_ = std::make_unique<Impl>();
-    // Push each group of transport-specific parameters into a separate sub-namespace
-    // ros::NodeHandle param_nh(transport_hints.getParameterNH(), getTransportName());
-    //
-    auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
-    impl_->sub_ = node->create_subscription<M>(
-      getTopicToSubscribe(base_topic), qos,
-      [this, callback](const typename std::shared_ptr<const M> msg) {
-        internalCallback(msg, callback);
-      });
-  }
-
-  void subscribeImplWithOptions(
-    rclcpp::Node * node,
-    const std::string & base_topic,
-    const Callback & callback,
     rmw_qos_profile_t custom_qos,
-    rclcpp::SubscriptionOptions options)
+    rclcpp::SubscriptionOptions options) override
   {
     impl_ = std::make_unique<Impl>();
     // Push each group of transport-specific parameters into a separate sub-namespace
@@ -144,6 +126,28 @@ protected:
         internalCallback(msg, callback);
       },
       options);
+  }
+
+  [[deprecated("Use subscribeImpl with five arguments instead by providing "
+               "rclcpp::SubscriptionOptions as fifth argument")]]
+  void subscribeImpl(
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    const Callback & callback,
+    rmw_qos_profile_t custom_qos) override
+  {
+    subscribeImpl(node, base_topic, callback, custom_qos, rclcpp::SubscriptionOptions());
+  }
+
+  [[deprecated("Use subscribeImpl with five arguments instead.")]]
+  void subscribeImplWithOptions(
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    const Callback & callback,
+    rmw_qos_profile_t custom_qos,
+    rclcpp::SubscriptionOptions options)
+  {
+    subscribeImpl(node, base_topic, callback, custom_qos, options);
   }
 
 private:

--- a/image_transport/include/image_transport/subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/subscriber_plugin.hpp
@@ -144,27 +144,29 @@ public:
 
 protected:
   /**
+   * \deprecated Use subscribeImpl with five parameters instead by providing
+   * rclcpp::SubscriptionOptions as fifth argument.
+   */
+  [[deprecated("Use subscribeImpl with five arguments instead by providing "
+               "rclcpp::SubscriptionOptions as fifth argument")]]
+  virtual void subscribeImpl(
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    const Callback & callback,
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
+    {
+      subscribeImpl(node, base_topic, callback, custom_qos, rclcpp::SubscriptionOptions());
+    }
+
+  /**
    * \brief Subscribe to an image transport topic. Must be implemented by the subclass.
    */
   virtual void subscribeImpl(
     rclcpp::Node * node,
     const std::string & base_topic,
     const Callback & callback,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default) = 0;
-
-  virtual void subscribeImpl(
-    rclcpp::Node * node,
-    const std::string & base_topic,
-    const Callback & callback,
     rmw_qos_profile_t custom_qos,
-    rclcpp::SubscriptionOptions options)
-  {
-    (void) options;
-    RCLCPP_ERROR(
-      node->get_logger(),
-      "SubscriberPlugin::subscribeImpl with five arguments has not been overridden");
-    this->subscribeImpl(node, base_topic, callback, custom_qos);
-  }
+    rclcpp::SubscriptionOptions options) = 0;
 };
 
 }  // namespace image_transport

--- a/image_transport/include/image_transport/subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/subscriber_plugin.hpp
@@ -154,9 +154,9 @@ protected:
     const std::string & base_topic,
     const Callback & callback,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
-    {
-      subscribeImpl(node, base_topic, callback, custom_qos, rclcpp::SubscriptionOptions());
-    }
+  {
+    subscribeImpl(node, base_topic, callback, custom_qos, rclcpp::SubscriptionOptions());
+  }
 
   /**
    * \brief Subscribe to an image transport topic. Must be implemented by the subclass.

--- a/image_transport/include/image_transport/subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/subscriber_plugin.hpp
@@ -144,6 +144,16 @@ public:
 
 protected:
   /**
+   * \brief Subscribe to an image transport topic. Must be implemented by the subclass.
+   */
+  virtual void subscribeImpl(
+    rclcpp::Node * node,
+    const std::string & base_topic,
+    const Callback & callback,
+    rmw_qos_profile_t custom_qos,
+    rclcpp::SubscriptionOptions options) = 0;
+
+  /**
    * \deprecated Use subscribeImpl with five parameters instead by providing
    * rclcpp::SubscriptionOptions as fifth argument.
    */
@@ -157,16 +167,6 @@ protected:
   {
     subscribeImpl(node, base_topic, callback, custom_qos, rclcpp::SubscriptionOptions());
   }
-
-  /**
-   * \brief Subscribe to an image transport topic. Must be implemented by the subclass.
-   */
-  virtual void subscribeImpl(
-    rclcpp::Node * node,
-    const std::string & base_topic,
-    const Callback & callback,
-    rmw_qos_profile_t custom_qos,
-    rclcpp::SubscriptionOptions options) = 0;
 };
 
 }  // namespace image_transport


### PR DESCRIPTION
Deprecate advertiseImpl and subscribeImpl without options.

These changes will warn any method that tries to call
* ``advertiseImpl`` or ``subscribeImpl`` with four arguments
* ``advertiseImplWithOptions``or ``subscribeImplWithOptions``

The only issue with this deprecation, is that we can't raise a warning for child classes that override ``advertiseImpl``or ``subscribeImpl``with four arguments. Maybe we can get away with adding the changes to the release notes.

There seems to be no image transports currently released outside those in image_transport_plugins, I can raise another PR for image_transport_plugins if this PR gets merged. 