### PR TITLE
Remove subscriber and plugin without options

### DIFF
--- a/image_transport/include/image_transport/publisher_plugin.hpp
+++ b/image_transport/include/image_transport/publisher_plugin.hpp
@@ -139,19 +139,6 @@ protected:
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos,
     rclcpp::PublisherOptions options) = 0;
-
-  /**
-   * \deprecated Use advertiseImpl with four parameters instead by providing
-   * rclcpp::PublisherOptions as fourth argument.
-   */
-  [[deprecated("Use advertiseImpl with four parameters instead by providing "
-               "rclcpp::PublisherOptions as fourth argument.")]]
-  virtual void advertiseImpl(
-    rclcpp::Node * nh, const std::string & base_topic,
-    rmw_qos_profile_t custom_qos)
-  {
-    advertiseImpl(nh, base_topic, custom_qos, rclcpp::PublisherOptions());
-  }
 };
 
 }  // namespace image_transport

--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -112,25 +112,6 @@ protected:
     simple_impl_->pub_ = node->create_publisher<M>(transport_topic, qos, options);
   }
 
-  [[deprecated("Use advertiseImpl with four parameters instead by providing "
-               "rclcpp::PublisherOptions as fourth argument.")]]
-  void advertiseImpl(
-    rclcpp::Node * node, const std::string & base_topic,
-    rmw_qos_profile_t custom_qos) override
-  {
-    advertiseImpl(node, base_topic, custom_qos, rclcpp::PublisherOptions{});
-  }
-
-  [[deprecated("Use advertiseImpl with four parameters instead.")]]
-  void advertiseImplWithOptions(
-    rclcpp::Node * node,
-    const std::string & base_topic,
-    rmw_qos_profile_t custom_qos,
-    rclcpp::PublisherOptions options)
-  {
-    advertiseImpl(node, base_topic, custom_qos, options);
-  }
-
   //! Generic function for publishing the internal message type.
   typedef std::function<void (const M &)> PublishFn;
 

--- a/image_transport/include/image_transport/simple_subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/simple_subscriber_plugin.hpp
@@ -128,28 +128,6 @@ protected:
       options);
   }
 
-  [[deprecated("Use subscribeImpl with five arguments instead by providing "
-               "rclcpp::SubscriptionOptions as fifth argument")]]
-  void subscribeImpl(
-    rclcpp::Node * node,
-    const std::string & base_topic,
-    const Callback & callback,
-    rmw_qos_profile_t custom_qos) override
-  {
-    subscribeImpl(node, base_topic, callback, custom_qos, rclcpp::SubscriptionOptions());
-  }
-
-  [[deprecated("Use subscribeImpl with five arguments instead.")]]
-  void subscribeImplWithOptions(
-    rclcpp::Node * node,
-    const std::string & base_topic,
-    const Callback & callback,
-    rmw_qos_profile_t custom_qos,
-    rclcpp::SubscriptionOptions options)
-  {
-    subscribeImpl(node, base_topic, callback, custom_qos, options);
-  }
-
 private:
   struct Impl
   {

--- a/image_transport/include/image_transport/subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/subscriber_plugin.hpp
@@ -152,21 +152,6 @@ protected:
     const Callback & callback,
     rmw_qos_profile_t custom_qos,
     rclcpp::SubscriptionOptions options) = 0;
-
-  /**
-   * \deprecated Use subscribeImpl with five parameters instead by providing
-   * rclcpp::SubscriptionOptions as fifth argument.
-   */
-  [[deprecated("Use subscribeImpl with five arguments instead by providing "
-               "rclcpp::SubscriptionOptions as fifth argument")]]
-  virtual void subscribeImpl(
-    rclcpp::Node * node,
-    const std::string & base_topic,
-    const Callback & callback,
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
-  {
-    subscribeImpl(node, base_topic, callback, custom_qos, rclcpp::SubscriptionOptions());
-  }
 };
 
 }  // namespace image_transport


### PR DESCRIPTION
An unexpected side effect of #249 breaks behaviours in classes downstream that inherit simple_subscriber_plugin.hpp. Removing the deprecated methods and causing compile errors downstream would be preferred to ensure smooth transition.

Resolves this issue (_Originally posted by @ivanpauno in https://github.com/ros-perception/image_common/issues/249#issuecomment-1204485423_):

> > That's not intended, and if that's happening then that'll defnitely be a bug. It should be showing a warning and still behaving correctly.
> 
> `CompressedPublisher::advertiseImpl()` (with options) is not being called anymore if you're holding a pointer to base.
> i.e.:
> 
> ```cpp
> PublisherPlugin * plugin_;
> ... // plugin is a CompressedPublisher instance
> plugin_->advertiseImpl(node, topic, qos, options);
> ```
> is calling this
> 
> https://github.com/ijnek/image_common/blob/74510a9ba6825dd0ddcbdd5a04ff9d34bad83da7/image_transport/include/image_transport/simple_publisher_plugin.hpp#L101
> 
> instead.
> 
> That's because the new method hasn't been overriden (only the old one without options), and `SimplePublisherPlugin` provides an implementation.
> Because of that, the parameters are not being declared and the plugin is being configured incorrectly.
> 