### PR TITLE
Add support for missing ROI and binning fields

### DIFF
--- a/camera_calibration_parsers/src/parse_yml.cpp
+++ b/camera_calibration_parsers/src/parse_yml.cpp
@@ -72,6 +72,14 @@ static const char D_YML_NAME[] = "distortion_coefficients";
 static const char R_YML_NAME[] = "rectification_matrix";
 static const char P_YML_NAME[] = "projection_matrix";
 static const char DMODEL_YML_NAME[] = "distortion_model";
+static const char BINNING_X_YML_NAME[] = "binning_x";
+static const char BINNING_Y_YML_NAME[] = "binning_y";
+static const char ROI_YML_NAME[] = "roi";
+static const char ROI_WIDTH_YML_NAME[] = "width";
+static const char ROI_HEIGHT_YML_NAME[] = "height";
+static const char ROI_X_OFFSET_YML_NAME[] = "x_offset";
+static const char ROI_Y_OFFSET_YML_NAME[] = "y_offset";
+static const char ROI_DO_RECTIFY_YML_NAME[] = "do_rectify";
 
 struct SimpleMatrix
 {
@@ -156,6 +164,20 @@ bool writeCalibrationYml(
   emitter << YAML::Key << P_YML_NAME << YAML::Value <<
     SimpleMatrix(3, 4, const_cast<double *>(&cam_info.p[0]));
 
+  // Binning
+  emitter << YAML::Key << BINNING_X_YML_NAME << YAML::Value << cam_info.binning_x;
+  emitter << YAML::Key << BINNING_Y_YML_NAME << YAML::Value << cam_info.binning_y;
+
+  // ROI
+  emitter << YAML::Key << ROI_YML_NAME << YAML::Value;
+  emitter << YAML::BeginMap;
+  emitter << YAML::Key << ROI_X_OFFSET_YML_NAME << YAML::Value << cam_info.roi.x_offset;
+  emitter << YAML::Key << ROI_Y_OFFSET_YML_NAME << YAML::Value << cam_info.roi.y_offset;
+  emitter << YAML::Key << ROI_HEIGHT_YML_NAME << YAML::Value << cam_info.roi.height;
+  emitter << YAML::Key << ROI_WIDTH_YML_NAME << YAML::Value << cam_info.roi.width;
+  emitter << YAML::Key << ROI_DO_RECTIFY_YML_NAME << YAML::Value << cam_info.roi.do_rectify;
+  emitter << YAML::EndMap;
+
   emitter << YAML::EndMap;
 
   out << emitter.c_str();
@@ -226,6 +248,22 @@ bool readCalibrationYml(
     cam_info.d.resize(D_rows * D_cols);
     for (int i = 0; i < D_rows * D_cols; ++i) {
       D_data[i] >> cam_info.d[i];
+    }
+
+    if (doc[BINNING_X_YML_NAME]) {
+      doc[BINNING_X_YML_NAME] >> cam_info.binning_x;
+    }
+    if (doc[BINNING_Y_YML_NAME]) {
+      doc[BINNING_Y_YML_NAME] >> cam_info.binning_y;
+    }
+
+    if (doc[ROI_YML_NAME]) {
+      const YAML::Node & roi_node = doc[ROI_YML_NAME];
+      roi_node[ROI_X_OFFSET_YML_NAME] >> cam_info.roi.x_offset;
+      roi_node[ROI_Y_OFFSET_YML_NAME] >> cam_info.roi.y_offset;
+      roi_node[ROI_HEIGHT_YML_NAME] >> cam_info.roi.height;
+      roi_node[ROI_WIDTH_YML_NAME] >> cam_info.roi.width;
+      roi_node[ROI_DO_RECTIFY_YML_NAME] >> cam_info.roi.do_rectify;
     }
 
     return true;

--- a/camera_calibration_parsers/test/make_calibs.hpp
+++ b/camera_calibration_parsers/test/make_calibs.hpp
@@ -78,9 +78,22 @@ void check_calib(sensor_msgs::msg::CameraInfo cam_info)
   } else {
     ADD_FAILURE() << "Unknown camera distortion model " << cam_info.distortion_model;
   }
+
+  if (cam_info.binning_x != 0 || cam_info.binning_y != 0) {
+    ASSERT_EQ(cam_info.binning_x, 1U);
+    ASSERT_EQ(cam_info.binning_y, 2U);
+  }
+
+  if (cam_info.roi.width != 0 || cam_info.roi.height != 0) {
+    ASSERT_EQ(cam_info.roi.width, 600U);
+    ASSERT_EQ(cam_info.roi.height, 300U);
+    ASSERT_EQ(cam_info.roi.x_offset, 20U);
+    ASSERT_EQ(cam_info.roi.y_offset, 180U);
+    ASSERT_EQ(cam_info.roi.do_rectify, true);
+  }
 }
 
-sensor_msgs::msg::CameraInfo make_calib(const std::string & distortion_model)
+sensor_msgs::msg::CameraInfo make_calib(const std::string & distortion_model, bool extended = false)
 {
   sensor_msgs::msg::CameraInfo cam_info;
   cam_info.width = 640;
@@ -97,6 +110,17 @@ sensor_msgs::msg::CameraInfo make_calib(const std::string & distortion_model)
     cam_info.d = {1, 2, 3, 4, 5, 6, 7, 8};
     cam_info.distortion_model = sensor_msgs::distortion_models::RATIONAL_POLYNOMIAL;
   }
+
+  if (extended) {
+    cam_info.binning_x = 1;
+    cam_info.binning_y = 2;
+    cam_info.roi.width = 600;
+    cam_info.roi.height = 300;
+    cam_info.roi.x_offset = 20;
+    cam_info.roi.y_offset = 180;
+    cam_info.roi.do_rectify = true;
+  }
+
   return cam_info;
 }
 

--- a/camera_calibration_parsers/test/test_parse_yml.cpp
+++ b/camera_calibration_parsers/test/test_parse_yml.cpp
@@ -175,3 +175,62 @@ TEST(ParseYml, roundtrip_calib8) {
   ASSERT_EQ(camera_name2, camera_name);
   check_calib(cam_info2);
 }
+
+static const char * kValidCalibRoi =
+  R"(
+image_width: 640
+image_height: 480
+camera_name: mono_left
+camera_matrix:
+  rows: 3
+  cols: 3
+  data: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+distortion_model: plumb_bob
+distortion_coefficients:
+  rows: 1
+  cols: 5
+  data: [1, 2, 3, 4, 5]
+rectification_matrix:
+  rows: 3
+  cols: 3
+  data: [1, 0, 0, 0, 1, 0, 0, 0, 1]
+projection_matrix:
+  rows: 3
+  cols: 4
+  data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+binning_x: 1
+binning_y: 2
+roi:
+  width: 600
+  height: 300
+  x_offset: 20
+  y_offset: 180
+  do_rectify: true
+)";
+
+TEST(ParseYml, kValidCalibRoi) {
+  std::string camera_name;
+  sensor_msgs::msg::CameraInfo cam_info;
+  auto ret = camera_calibration_parsers::parseCalibrationYml(kValidCalibRoi, camera_name, cam_info);
+  ASSERT_EQ(ret, true);
+  ASSERT_EQ(camera_name, "mono_left");
+  check_calib(cam_info);
+}
+
+TEST(ParseYml, roundtrip_calib_roi) {
+  std::string calib_file = custom_tmpnam();
+
+  std::string camera_name = "roundtrip_calib_roi";
+  auto cam_info = make_calib(sensor_msgs::distortion_models::PLUMB_BOB, true);
+  auto ret_write = camera_calibration_parsers::writeCalibrationYml(
+    calib_file, camera_name, cam_info);
+  ASSERT_EQ(ret_write, true);
+
+  std::string camera_name2;
+  sensor_msgs::msg::CameraInfo cam_info2;
+  auto ret_read = camera_calibration_parsers::readCalibrationYml(
+    calib_file, camera_name2, cam_info2);
+  ASSERT_EQ(ret_read, true);
+  ASSERT_EQ(camera_name2, camera_name);
+  check_calib(cam_info2);
+}


### PR DESCRIPTION
Equivalently to #175 for ROS1, this pull request adds support for binning and roi fields contained in the CameraInfo.msg to the `camera_calibration_parsers` package for ROS2. So that it is able to write these fields to YAML and to read them from YAML.

To properly use the ROI information I also made this pull request ros2/rviz#864 to Rviz.