### PR TITLE
Add another constructor for image_transport

### DIFF
--- a/image_transport/include/image_transport/image_transport.hpp
+++ b/image_transport/include/image_transport/image_transport.hpp
@@ -112,11 +112,9 @@ public:
   using ImageConstPtr = sensor_msgs::msg::Image::ConstSharedPtr;
   using CameraInfoConstPtr = sensor_msgs::msg::CameraInfo::ConstSharedPtr;
 
+  template <typename NodeT>
   IMAGE_TRANSPORT_PUBLIC
-  explicit ImageTransport(rclcpp::Node::SharedPtr node);
-
-  IMAGE_TRANSPORT_PUBLIC
-  explicit ImageTransport(rclcpp::Node* node);
+  explicit ImageTransport(NodeT node);
 
   IMAGE_TRANSPORT_PUBLIC
   ~ImageTransport();
@@ -290,6 +288,19 @@ private:
   struct Impl;
   std::unique_ptr<Impl> impl_;
 };
+
+struct ImageTransport::Impl
+{
+  rclcpp::Node::SharedPtr node_;
+};
+
+template <typename NodeT>
+ImageTransport::ImageTransport(NodeT node)
+  : impl_(std::make_unique<ImageTransport::Impl>())
+{
+  std::shared_ptr<rclcpp::Node> ptr{node};
+  impl_->node_ = ptr;
+}
 
 }  // namespace image_transport
 

--- a/image_transport/include/image_transport/image_transport.hpp
+++ b/image_transport/include/image_transport/image_transport.hpp
@@ -116,6 +116,9 @@ public:
   explicit ImageTransport(rclcpp::Node::SharedPtr node);
 
   IMAGE_TRANSPORT_PUBLIC
+  explicit ImageTransport(rclcpp::Node* node);
+
+  IMAGE_TRANSPORT_PUBLIC
   ~ImageTransport();
 
   /*!

--- a/image_transport/src/image_transport.cpp
+++ b/image_transport/src/image_transport.cpp
@@ -128,24 +128,6 @@ std::vector<std::string> getLoadableTransports()
   return loadableTransports;
 }
 
-struct ImageTransport::Impl
-{
-  rclcpp::Node::SharedPtr node_;
-};
-
-ImageTransport::ImageTransport(rclcpp::Node::SharedPtr node)
-: impl_(std::make_unique<ImageTransport::Impl>())
-{
-  impl_->node_ = node;
-}
-
-ImageTransport::ImageTransport(rclcpp::Node* node)
-: impl_(std::make_unique<ImageTransport::Impl>())
-{
-  std::shared_ptr<rclcpp::Node> ptr{node};
-  impl_->node_ = ptr;
-}
-
 ImageTransport::~ImageTransport() = default;
 
 Publisher ImageTransport::advertise(const std::string & base_topic, uint32_t queue_size, bool latch)

--- a/image_transport/src/image_transport.cpp
+++ b/image_transport/src/image_transport.cpp
@@ -139,6 +139,13 @@ ImageTransport::ImageTransport(rclcpp::Node::SharedPtr node)
   impl_->node_ = node;
 }
 
+ImageTransport::ImageTransport(rclcpp::Node* node)
+: impl_(std::make_unique<ImageTransport::Impl>())
+{
+  std::shared_ptr<rclcpp::Node> ptr{node};
+  impl_->node_ = ptr;
+}
+
 ImageTransport::~ImageTransport() = default;
 
 Publisher ImageTransport::advertise(const std::string & base_topic, uint32_t queue_size, bool latch)


### PR DESCRIPTION
The `image_transport::ImageTransport` has the only constructor with input argument `rclcpp::Node::SharedPtr`, and we have to write both `rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("image_publisher", options);` and `image_transport::ImageTransport it(node);` inside the main function, which is not recommended by ROS2 style.

By adding another constructor, we now can move all the declarations into the class and follow the recommended structure to write the node: create a class which inherits from `rclcpp::Node`.

A minimal subscriber example:
```cpp
#include <rclcpp/rclcpp.hpp>
#include <image_transport/image_transport.hpp>
#include <cv_bridge/cv_bridge.h>
#include <opencv2/highgui/highgui.hpp>

class MinimalSubscriber: public rclcpp::Node
{
  public:
    MinimalSubscriber()
      : Node("minimal_subscriber"), it_(this)
    {
      subscriber_ = it_.subscribe("camera/image", 1,
        std::bind(&MinimalSubscriber::image_callback, this, std::placeholders::_1));
    }

  private:
    void image_callback(const sensor_msgs::msg::Image::ConstSharedPtr& msg)
    {
      try {
        cv::imshow("view", cv_bridge::toCvShare(msg, "bgr8")->image);
        cv::waitKey(10);
      } catch (cv_bridge::Exception& e) {
        auto logger = rclcpp::get_logger("my_subscriber");
        RCLCPP_ERROR(logger, "Could not convert from '%s' to 'bgr8'.", msg->encoding.c_str());
      }
    }

    image_transport::Subscriber subscriber_;
    image_transport::ImageTransport it_;
};

int main(int argc, char* argv[])
{
  rclcpp::init(argc, argv);
  cv::namedWindow("view");
  cv::startWindowThread();
  rclcpp::spin(std::make_shared<MinimalSubscriber>());
  cv::destroyWindow("view");
  rclcpp::shutdown();
  return 0;
}
```
A minimal publisher example:
```cpp
#include <rclcpp/rclcpp.hpp>
#include <image_transport/image_transport.hpp>
#include <cv_bridge/cv_bridge.h>
#include <opencv2/highgui/highgui.hpp>

using namespace std::chrono_literals;

class MinimalPublisher: public rclcpp::Node
{
public:
  MinimalPublisher(const cv::Mat& image)
    : Node("minimal_publisher"), it_(this), image_(image)
  {
    publisher_ = it_.advertise("camera/image", 1);
    timer_ = this->create_wall_timer(
      500ms, std::bind(&MinimalPublisher::timer_callback, this));
  }

private:
  void timer_callback()
  {
    std_msgs::msg::Header hdr;
    sensor_msgs::msg::Image::SharedPtr msg = cv_bridge::CvImage(hdr, "bgr8", image_).toImageMsg();
    publisher_.publish(msg);
  }

  image_transport::Publisher publisher_;
  rclcpp::TimerBase::SharedPtr timer_;
  image_transport::ImageTransport it_;
  cv::Mat image_;
};

int main(int argc, char* argv[])
{
  cv::Mat image = cv::imread(argv[1], cv::IMREAD_COLOR);

  rclcpp::init(argc, argv);
  rclcpp::spin(std::make_shared<MinimalPublisher>(image));
  rclcpp::shutdown();
  return 0;
}
```