### PR TITLE
Expose option to set callback groups

### DIFF
--- a/image_transport/include/image_transport/image_transport.hpp
+++ b/image_transport/include/image_transport/image_transport.hpp
@@ -164,7 +164,8 @@ public:
   Subscriber subscribe(
     const std::string & base_topic, uint32_t queue_size,
     void (T::* fp)(const ImageConstPtr &), T * obj,
-    const TransportHints * transport_hints = nullptr)
+    const TransportHints * transport_hints = nullptr,
+    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
   {
     return subscribe(
       base_topic, queue_size, std::bind(fp, obj, std::placeholders::_1),
@@ -179,7 +180,8 @@ public:
     const std::string & base_topic, uint32_t queue_size,
     void (T::* fp)(const ImageConstPtr &),
     const std::shared_ptr<T> & obj,
-    const TransportHints * transport_hints = nullptr)
+    const TransportHints * transport_hints = nullptr,
+    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
   {
     return subscribe(
       base_topic, queue_size, std::bind(fp, obj.get(), std::placeholders::_1),

--- a/image_transport/include/image_transport/image_transport.hpp
+++ b/image_transport/include/image_transport/image_transport.hpp
@@ -169,7 +169,7 @@ public:
   {
     return subscribe(
       base_topic, queue_size, std::bind(fp, obj, std::placeholders::_1),
-      VoidPtr(), transport_hints);
+      VoidPtr(), transport_hints, options);
   }
 
   /**
@@ -185,7 +185,7 @@ public:
   {
     return subscribe(
       base_topic, queue_size, std::bind(fp, obj.get(), std::placeholders::_1),
-      obj, transport_hints);
+      obj, transport_hints, options);
   }
 
   /*!

--- a/image_transport/include/image_transport/image_transport.hpp
+++ b/image_transport/include/image_transport/image_transport.hpp
@@ -138,7 +138,8 @@ public:
     const std::string & base_topic, uint32_t queue_size,
     const Subscriber::Callback & callback,
     const VoidPtr & tracked_object = VoidPtr(),
-    const TransportHints * transport_hints = nullptr);
+    const TransportHints * transport_hints = nullptr,
+    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions());
 
   /**
    * \brief Subscribe to an image topic, version for bare function.
@@ -147,12 +148,13 @@ public:
   Subscriber subscribe(
     const std::string & base_topic, uint32_t queue_size,
     void (* fp)(const ImageConstPtr &),
-    const TransportHints * transport_hints = nullptr)
+    const TransportHints * transport_hints = nullptr,
+    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
   {
     return subscribe(
       base_topic, queue_size,
       std::function<void(const ImageConstPtr &)>(fp),
-      VoidPtr(), transport_hints);
+      VoidPtr(), transport_hints, options);
   }
 
   /**

--- a/image_transport/src/image_transport.cpp
+++ b/image_transport/src/image_transport.cpp
@@ -153,14 +153,16 @@ Subscriber ImageTransport::subscribe(
   const std::string & base_topic, uint32_t queue_size,
   const Subscriber::Callback & callback,
   const VoidPtr & tracked_object,
-  const TransportHints * transport_hints)
+  const TransportHints * transport_hints,
+  const rclcpp::SubscriptionOptions options)
 {
   (void) tracked_object;
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
   custom_qos.depth = queue_size;
   return create_subscription(
     impl_->node_.get(), base_topic, callback,
-    getTransportOrDefault(transport_hints), custom_qos);
+    getTransportOrDefault(transport_hints), custom_qos,
+    options);
 }
 
 CameraPublisher ImageTransport::advertiseCamera(

--- a/image_transport/test/test_subscriber.cpp
+++ b/image_transport/test/test_subscriber.cpp
@@ -125,12 +125,12 @@ TEST_F(TestSubscriber, callback_groups) {
   // The callbacks sleep for 5 seconds and mutually exclusive callbacks should be blocked.
   // However, because of the the multithreaded executor and renentrant callback group,
   // the flags should be set, as the callbacks should be in different threads.
-  auto timeout_elapsed = 0;
-  auto sleep_duration = 0.1;
-  auto timeout = 0.5;
+  auto timeout_elapsed = 0.0s;
+  auto sleep_duration = 0.1s;
+  auto timeout = 0.5s;
 
   while (!(flag_1 && flag_2)) {
-    sleep(sleep_duration);
+    std::this_thread::sleep_for(sleep_duration);
     timeout_elapsed += sleep_duration;
   }
   executor.cancel();

--- a/image_transport/test/test_subscriber.cpp
+++ b/image_transport/test/test_subscriber.cpp
@@ -89,7 +89,7 @@ TEST_F(TestSubscriber, callback_groups) {
   image_transport::Publisher pub = it_publisher.advertise("camera/image", 1);
 
   auto msg = sensor_msgs::msg::Image();
-  auto timer = node_publisher->create_wall_timer(100ms, [&](){ pub.publish(msg); });
+  auto timer = node_publisher->create_wall_timer(100ms, [&]() {pub.publish(msg);});
 
   // Create a subscriber to read the images.
   std::atomic<bool> flag_1 = false;
@@ -120,7 +120,7 @@ TEST_F(TestSubscriber, callback_groups) {
   executor.add_node(node_);
   executor.add_node(node_publisher);
   // Both callbacks should be executed and the flags should be set.
-  std::thread executor_thread([&](){executor.spin();});
+  std::thread executor_thread([&]() {executor.spin();});
 
   // The callbacks sleep for 5 seconds and mutually exclusive callbacks should be blocked.
   // However, because of the the multithreaded executor and renentrant callback group,
@@ -129,7 +129,7 @@ TEST_F(TestSubscriber, callback_groups) {
   auto sleep_duration = 0.1;
   auto timeout = 0.5;
 
-  while(!(flag_1 && flag_2)) {
+  while (!(flag_1 && flag_2)) {
     sleep(sleep_duration);
     timeout_elapsed += sleep_duration;
   }

--- a/image_transport/test/test_subscriber.cpp
+++ b/image_transport/test/test_subscriber.cpp
@@ -98,13 +98,13 @@ TEST_F(TestSubscriber, callback_groups) {
     [&](const auto & msg) {
       (void)msg;
       flag_1 = true;
-      std::this_thread::sleep_for(5s);
+      std::this_thread::sleep_for(1s);
     };
   std::function<void(const sensor_msgs::msg::Image::ConstSharedPtr & msg)> fcn2 =
     [&](const auto & msg) {
       (void)msg;
       flag_2 = true;
-      std::this_thread::sleep_for(5s);
+      std::this_thread::sleep_for(1s);
     };
 
   auto cb_group = node_->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
@@ -134,6 +134,7 @@ TEST_F(TestSubscriber, callback_groups) {
     timeout_elapsed += sleep_duration;
   }
   executor.cancel();
+  executor_thread.join();
 
   EXPECT_LT(timeout_elapsed, timeout);
 }

--- a/image_transport/test/test_subscriber.cpp
+++ b/image_transport/test/test_subscriber.cpp
@@ -92,8 +92,8 @@ TEST_F(TestSubscriber, callback_groups) {
 
   image_transport::ImageTransport it(node_);
 
-  auto subscriber1 = it.subscribe("camera/image", 1, fcn1, nullptr, sub_options);
-  auto subscriber2 = it.subscribe("camera/image", 1, fcn2, nullptr, sub_options);
+  auto subscriber1 = it.subscribe("camera/image", 1, fcn1, nullptr, nullptr, sub_options);
+  auto subscriber2 = it.subscribe("camera/image", 1, fcn2, nullptr, nullptr, sub_options);
 
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.spin_node_some(node_);


### PR DESCRIPTION
This PR exposes the option to set SubscriptionOptionsm inside which one can set callback groups. This breaks ABI, but that should be fine for rolling.

Usage : https://github.com/adityapande-1995/img_transport_cb/blob/260897bfd8b369c998b81fcc614af948ddfb0a3a/src/my_subscriber.cpp#L59-L62

