### PR TITLE
Add missing definition for CameraPublisher::publish overload

### DIFF
--- a/image_transport/src/camera_publisher.cpp
+++ b/image_transport/src/camera_publisher.cpp
@@ -153,6 +153,25 @@ void CameraPublisher::publish(
   impl_->info_pub_->publish(*info);
 }
 
+void CameraPublisher::publish(
+  sensor_msgs::msg::Image & image, sensor_msgs::msg::CameraInfo & info,
+  rclcpp::Time stamp) const
+{
+  if (!impl_ || !impl_->isValid()) {
+    // TODO(ros2) Switch to RCUTILS_ASSERT when ros2/rcutils#112 is merged
+    auto logger = impl_ ? impl_->logger_ : rclcpp::get_logger("image_transport");
+    RCLCPP_FATAL(
+      logger,
+      "Call to publish() on an invalid image_transport::CameraPublisher");
+    return;
+  }
+
+  image.header.stamp = stamp;
+  info.header.stamp = stamp;
+  impl_->image_pub_.publish(image);
+  impl_->info_pub_->publish(info);
+}
+
 void CameraPublisher::shutdown()
 {
   if (impl_) {

--- a/image_transport/test/test_publisher.cpp
+++ b/image_transport/test/test_publisher.cpp
@@ -73,6 +73,9 @@ TEST_F(TestPublisher, camera_publisher) {
   camera_pub.publish(
     sensor_msgs::msg::Image::ConstSharedPtr(),
     sensor_msgs::msg::CameraInfo::ConstSharedPtr());
+  sensor_msgs::msg::Image image;
+  sensor_msgs::msg::CameraInfo info;
+  camera_pub.publish(image, info, rclcpp::Time());
 }
 
 TEST_F(TestPublisher, image_transport_camera_publisher) {


### PR DESCRIPTION
Adds missing definition for [this](https://github.com/ros-perception/image_common/blob/4965283b25764177d5df41b7a645e81b4cd86647/image_transport/include/image_transport/camera_publisher.hpp#L122) overload and corresponding coverage test.