### PR TITLE
Drop pkg-config logic to find yaml-cpp.

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -15,19 +15,9 @@ catkin_package(
   CATKIN_DEPENDS sensor_msgs
 )
 
-find_package(PkgConfig)
-
-
-if (ANDROID)
-    find_package(yaml-cpp)
-    add_definitions(-DHAVE_NEW_YAMLCPP)
-else()
-  pkg_check_modules(YAML_CPP yaml-cpp)
-  if(${YAML_CPP_VERSION} VERSION_GREATER 0.5)
-    add_definitions(-DHAVE_NEW_YAMLCPP)
-  endif()
-  link_directories(${YAML_CPP_LIBRARY_DIRS})
-endif()
+find_package(yaml-cpp)
+add_definitions(-DHAVE_NEW_YAMLCPP)
+link_directories(${YAML_CPP_LIBRARY_DIRS})
 include_directories(${YAML_CPP_INCLUDE_DIRS})
 
 # define the library

--- a/camera_calibration_parsers/package.xml
+++ b/camera_calibration_parsers/package.xml
@@ -16,7 +16,6 @@
   <buildtool_depend>catkin</buildtool_depend>
   
   <build_depend>boost</build_depend>
-  <build_depend>pkg-config</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>yaml-cpp</build_depend>


### PR DESCRIPTION
Modern platforms include CMake find modules for yaml-cpp, including Ubuntu Focal:

https://packages.ubuntu.com/focal/amd64/libyaml-cpp-dev/filelist

This extra logic was tripping up my NixOS 23.05 build:

```
camera_calibration_parsers> -- Checking for module 'yaml-cpp'
camera_calibration_parsers> --   No package 'yaml-cpp' found
camera_calibration_parsers> CMake Error at CMakeLists.txt:33 (if):
camera_calibration_parsers>   if given arguments:
camera_calibration_parsers>     "VERSION_GREATER" "0.5"
camera_calibration_parsers>   Unknown arguments specified
```