### PR TITLE
Revert "Expose callback groups - backport to humble (#277)"

### DIFF
--- a/image_transport/include/image_transport/image_transport.hpp
+++ b/image_transport/include/image_transport/image_transport.hpp
@@ -140,17 +140,6 @@ public:
     const TransportHints * transport_hints = nullptr);
 
   /**
-   * \brief Subscribe to an image topic, version for arbitrary std::function object.
-   */
-  IMAGE_TRANSPORT_PUBLIC
-  Subscriber subscribe(
-    const std::string & base_topic, uint32_t queue_size,
-    const Subscriber::Callback & callback,
-    const VoidPtr & tracked_object = VoidPtr(),
-    const TransportHints * transport_hints = nullptr,
-    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions());
-
-  /**
    * \brief Subscribe to an image topic, version for bare function.
    */
   IMAGE_TRANSPORT_PUBLIC
@@ -162,23 +151,7 @@ public:
     return subscribe(
       base_topic, queue_size,
       std::function<void(const ImageConstPtr &)>(fp),
-      VoidPtr(), transport_hints, rclcpp::SubscriptionOptions());
-  }
-
-  /**
-   * \brief Subscribe to an image topic, version for bare function.
-   */
-  IMAGE_TRANSPORT_PUBLIC
-  Subscriber subscribe(
-    const std::string & base_topic, uint32_t queue_size,
-    void (* fp)(const ImageConstPtr &),
-    const TransportHints * transport_hints = nullptr,
-    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
-  {
-    return subscribe(
-      base_topic, queue_size,
-      std::function<void(const ImageConstPtr &)>(fp),
-      VoidPtr(), transport_hints, options);
+      VoidPtr(), transport_hints);
   }
 
   /**
@@ -196,21 +169,6 @@ public:
   }
 
   /**
-   * \brief Subscribe to an image topic, version for class member function with bare pointer.
-   */
-  template<class T>
-  Subscriber subscribe(
-    const std::string & base_topic, uint32_t queue_size,
-    void (T::* fp)(const ImageConstPtr &), T * obj,
-    const TransportHints * transport_hints = nullptr,
-    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
-  {
-    return subscribe(
-      base_topic, queue_size, std::bind(fp, obj, std::placeholders::_1),
-      VoidPtr(), transport_hints, options);
-  }
-
-  /**
    * \brief Subscribe to an image topic, version for class member function with shared_ptr.
    */
   template<class T>
@@ -223,22 +181,6 @@ public:
     return subscribe(
       base_topic, queue_size, std::bind(fp, obj.get(), std::placeholders::_1),
       obj, transport_hints);
-  }
-
-  /**
-   * \brief Subscribe to an image topic, version for class member function with shared_ptr.
-   */
-  template<class T>
-  Subscriber subscribe(
-    const std::string & base_topic, uint32_t queue_size,
-    void (T::* fp)(const ImageConstPtr &),
-    const std::shared_ptr<T> & obj,
-    const TransportHints * transport_hints = nullptr,
-    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
-  {
-    return subscribe(
-      base_topic, queue_size, std::bind(fp, obj.get(), std::placeholders::_1),
-      obj, transport_hints, options);
   }
 
   /*!

--- a/image_transport/src/image_transport.cpp
+++ b/image_transport/src/image_transport.cpp
@@ -162,22 +162,6 @@ Subscriber ImageTransport::subscribe(
     getTransportOrDefault(transport_hints), custom_qos);
 }
 
-Subscriber ImageTransport::subscribe(
-  const std::string & base_topic, uint32_t queue_size,
-  const Subscriber::Callback & callback,
-  const VoidPtr & tracked_object,
-  const TransportHints * transport_hints,
-  const rclcpp::SubscriptionOptions options)
-{
-  (void) tracked_object;
-  rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
-  custom_qos.depth = queue_size;
-  return create_subscription(
-    impl_->node_.get(), base_topic, callback,
-    getTransportOrDefault(transport_hints), custom_qos,
-    options);
-}
-
 CameraPublisher ImageTransport::advertiseCamera(
   const std::string & base_topic, uint32_t queue_size,
   bool latch)


### PR DESCRIPTION
This reverts commit 3013dfea73c14360700fafa6c4ef7d6e8e8e367f.

The original commit broke downstream packages, reverting it until a solution is found and deployed.