### PR TITLE
Fix downstream regressions due to subscribe overloads

### DIFF
--- a/image_transport/include/image_transport/image_transport.hpp
+++ b/image_transport/include/image_transport/image_transport.hpp
@@ -147,9 +147,9 @@ public:
   Subscriber subscribe(
     const std::string & base_topic, uint32_t queue_size,
     const Subscriber::Callback & callback,
-    const VoidPtr & tracked_object = VoidPtr(),
-    const TransportHints * transport_hints = nullptr,
-    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions());
+    const VoidPtr & tracked_object,
+    const TransportHints * transport_hints,
+    const rclcpp::SubscriptionOptions options);
 
   /**
    * \brief Subscribe to an image topic, version for bare function.
@@ -173,8 +173,8 @@ public:
   Subscriber subscribe(
     const std::string & base_topic, uint32_t queue_size,
     void (* fp)(const ImageConstPtr &),
-    const TransportHints * transport_hints = nullptr,
-    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
+    const TransportHints * transport_hints,
+    const rclcpp::SubscriptionOptions options)
   {
     return subscribe(
       base_topic, queue_size,
@@ -203,8 +203,8 @@ public:
   Subscriber subscribe(
     const std::string & base_topic, uint32_t queue_size,
     void (T::* fp)(const ImageConstPtr &), T * obj,
-    const TransportHints * transport_hints = nullptr,
-    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
+    const TransportHints * transport_hints,
+    const rclcpp::SubscriptionOptions options)
   {
     return subscribe(
       base_topic, queue_size, std::bind(fp, obj, std::placeholders::_1),
@@ -234,8 +234,8 @@ public:
     const std::string & base_topic, uint32_t queue_size,
     void (T::* fp)(const ImageConstPtr &),
     const std::shared_ptr<T> & obj,
-    const TransportHints * transport_hints = nullptr,
-    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
+    const TransportHints * transport_hints,
+    const rclcpp::SubscriptionOptions options)
   {
     return subscribe(
       base_topic, queue_size, std::bind(fp, obj.get(), std::placeholders::_1),


### PR DESCRIPTION
Fixes https://github.com/ros-perception/image_common/issues/279 for iron