### PR TITLE
Switch to using the override keyword for simple_publisher_plugin.

### DIFF
--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -65,7 +65,7 @@ class SimplePublisherPlugin : public PublisherPlugin
 public:
   virtual ~SimplePublisherPlugin() {}
 
-  virtual size_t getNumSubscribers() const
+  size_t getNumSubscribers() const override
   {
     if (simple_impl_) {
       return simple_impl_->pub_->get_subscription_count();
@@ -73,13 +73,13 @@ public:
     return 0;
   }
 
-  virtual std::string getTopic() const
+  std::string getTopic() const override
   {
     if (simple_impl_) {return simple_impl_->pub_->get_topic_name();}
     return std::string();
   }
 
-  virtual void publish(const sensor_msgs::msg::Image & message) const
+  void publish(const sensor_msgs::msg::Image & message) const override
   {
     if (!simple_impl_ || !simple_impl_->pub_) {
       auto logger = simple_impl_ ? simple_impl_->logger_ : rclcpp::get_logger("image_transport");
@@ -92,7 +92,7 @@ public:
     publish(message, bindInternalPublisher(simple_impl_->pub_.get()));
   }
 
-  virtual void shutdown()
+  void shutdown() override
   {
     simple_impl_.reset();
   }


### PR DESCRIPTION
This resolves a warning pointed out by building with clang.