### PR TITLE
ros2 fixed camera_info service

### DIFF
--- a/camera_info_manager/src/camera_info_manager.cpp
+++ b/camera_info_manager/src/camera_info_manager.cpp
@@ -88,7 +88,7 @@ CameraInfoManager::CameraInfoManager(
 {
   // register callback for camera calibration service request
   info_service_ = node->create_service<SetCameraInfo>(
-    "set_camera_info",
+    cname + "/set_camera_info",
     std::bind(
       &CameraInfoManager::setCameraInfoService, this, std::placeholders::_1,
       std::placeholders::_2));
@@ -617,3 +617,4 @@ bool CameraInfoManager::validateURL(const std::string & url)
   return url_type < URL_invalid;
 }
 }  // namespace camera_info_manager
+


### PR DESCRIPTION
I use two stereo cameras. When I calibrated the cameras with the ROS calibrator, after clicking on **commit**, the tool wrote **four** files simultaneously: `cam_0.yaml` and `cam_1.yaml` with the parameters of the left camera, and `cam_0.yaml` and `cam_1.yaml` with the parameters of the right camera. This caused me to lose the configuration of one camera.

The issue arises from both cameras using the same service: `/camera_info`. I resolved this problem by adding the camera's name in the constructor.