### PR TITLE
Update to yaml-cpp 0.8.0.

### DIFF
--- a/camera_calibration_parsers/CMakeLists.txt
+++ b/camera_calibration_parsers/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 # define the library
 add_library(${PROJECT_NAME}
@@ -28,10 +29,10 @@ add_library(${PROJECT_NAME}
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} PUBLIC
-  ${sensor_msgs_TARGETS}
-  ${yaml_cpp_vendor_TARGETS})
+  ${sensor_msgs_TARGETS})
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  rclcpp::rclcpp)
+  rclcpp::rclcpp
+  yaml-cpp::yaml-cpp)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -63,7 +64,7 @@ ament_export_targets(export_${PROJECT_NAME})
 
 # define the exe to convert
 add_executable(convert src/convert.cpp)
-target_link_libraries(convert
+target_link_libraries(convert PRIVATE
   ${PROJECT_NAME}
   rclcpp::rclcpp)
 

--- a/camera_calibration_parsers/include/camera_calibration_parsers/parse_ini.hpp
+++ b/camera_calibration_parsers/include/camera_calibration_parsers/parse_ini.hpp
@@ -35,6 +35,8 @@
 #ifndef CAMERA_CALIBRATION_PARSERS__PARSE_INI_HPP_
 #define CAMERA_CALIBRATION_PARSERS__PARSE_INI_HPP_
 
+#include <istream>
+#include <ostream>
 #include <string>
 
 #include "sensor_msgs/msg/camera_info.hpp"

--- a/camera_calibration_parsers/include/camera_calibration_parsers/parse_yml.hpp
+++ b/camera_calibration_parsers/include/camera_calibration_parsers/parse_yml.hpp
@@ -35,9 +35,9 @@
 #ifndef CAMERA_CALIBRATION_PARSERS__PARSE_YML_HPP_
 #define CAMERA_CALIBRATION_PARSERS__PARSE_YML_HPP_
 
-#include <string>
 #include <istream>
 #include <ostream>
+#include <string>
 
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "camera_calibration_parsers/visibility_control.hpp"


### PR DESCRIPTION
In particular, yaml-cpp 0.8.0 has a proper CMake target of yaml-cpp::yaml-cpp, so use that here.  Also fix up a couple of other minor issues while we are looking at the code.

Depends on https://github.com/ros2/yaml_cpp_vendor/pull/48 , so it should not be merged before that one.