### PR TITLE
Support zero-copy intra-process publishing

### DIFF
--- a/image_transport/include/image_transport/camera_publisher.hpp
+++ b/image_transport/include/image_transport/camera_publisher.hpp
@@ -112,6 +112,14 @@ public:
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info) const;
 
   /*!
+   * \brief Publish an (image, info) pair on the topics associated with this CameraPublisher.
+   */
+  IMAGE_TRANSPORT_PUBLIC
+  void publish(
+    sensor_msgs::msg::Image::UniquePtr image,
+    sensor_msgs::msg::CameraInfo::UniquePtr info) const;
+
+  /*!
    * \brief Publish an (image, info) pair with given timestamp on the topics associated with
    * this CameraPublisher.
    *
@@ -121,6 +129,19 @@ public:
   IMAGE_TRANSPORT_PUBLIC
   void publish(
     sensor_msgs::msg::Image & image, sensor_msgs::msg::CameraInfo & info,
+    rclcpp::Time stamp) const;
+
+  /*!
+   * \brief Publish an (image, info) pair with given timestamp on the topics associated with
+   * this CameraPublisher.
+   *
+   * Convenience version, which sets the timestamps of both image and info to stamp before
+   * publishing.
+   */
+  IMAGE_TRANSPORT_PUBLIC
+  void publish(
+    sensor_msgs::msg::Image::UniquePtr image,
+    sensor_msgs::msg::CameraInfo::UniquePtr info,
     rclcpp::Time stamp) const;
 
   /*!

--- a/image_transport/include/image_transport/publisher.hpp
+++ b/image_transport/include/image_transport/publisher.hpp
@@ -104,6 +104,12 @@ public:
   void publish(const sensor_msgs::msg::Image::ConstSharedPtr & message) const;
 
   /*!
+   * \brief Publish an image on the topics associated with this Publisher.
+   */
+  IMAGE_TRANSPORT_PUBLIC
+  void publish(sensor_msgs::msg::Image::UniquePtr message) const;
+
+  /*!
    * \brief Shutdown the advertisements associated with this Publisher.
    */
   IMAGE_TRANSPORT_PUBLIC

--- a/image_transport/include/image_transport/publisher_plugin.hpp
+++ b/image_transport/include/image_transport/publisher_plugin.hpp
@@ -60,6 +60,14 @@ public:
   virtual std::string getTransportName() const = 0;
 
   /**
+   * \brief Check whether this plugin supports publishing using UniquePtr.
+   */
+  virtual bool supportsUniquePtrPub() const
+  {
+    return false;
+  }
+
+  /**
    * \brief Advertise a topic, simple version.
    */
   void advertise(
@@ -91,6 +99,18 @@ public:
    * \brief Publish an image using the transport associated with this PublisherPlugin.
    */
   virtual void publishPtr(const sensor_msgs::msg::Image::ConstSharedPtr & message) const
+  {
+    publish(*message);
+  }
+
+  /**
+   * \brief Publish an image using the transport associated with this PublisherPlugin.
+   * This version of the function can be used to optimize cases where the Plugin can 
+   * avoid doing copies of the data when having the ownership to the image message.
+   * Plugins that can take advantage of message ownership should overwrite this method
+   * along with supportsUniquePtrPub().
+   */
+  virtual void publishUniquePtr(sensor_msgs::msg::Image::UniquePtr message) const
   {
     publish(*message);
   }

--- a/image_transport/include/image_transport/publisher_plugin.hpp
+++ b/image_transport/include/image_transport/publisher_plugin.hpp
@@ -29,6 +29,7 @@
 #ifndef IMAGE_TRANSPORT__PUBLISHER_PLUGIN_HPP_
 #define IMAGE_TRANSPORT__PUBLISHER_PLUGIN_HPP_
 
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -110,9 +111,9 @@ public:
    * Plugins that can take advantage of message ownership should overwrite this method
    * along with supportsUniquePtrPub().
    */
-  virtual void publishUniquePtr(sensor_msgs::msg::Image::UniquePtr message) const
+  virtual void publishUniquePtr(sensor_msgs::msg::Image::UniquePtr /*message*/) const
   {
-    publish(*message);
+    throw std::logic_error("publishUniquePtr() is not implemented.");
   }
 
   /**

--- a/image_transport/include/image_transport/publisher_plugin.hpp
+++ b/image_transport/include/image_transport/publisher_plugin.hpp
@@ -105,7 +105,7 @@ public:
 
   /**
    * \brief Publish an image using the transport associated with this PublisherPlugin.
-   * This version of the function can be used to optimize cases where the Plugin can 
+   * This version of the function can be used to optimize cases where the Plugin can
    * avoid doing copies of the data when having the ownership to the image message.
    * Plugins that can take advantage of message ownership should overwrite this method
    * along with supportsUniquePtrPub().

--- a/image_transport/include/image_transport/raw_publisher.hpp
+++ b/image_transport/include/image_transport/raw_publisher.hpp
@@ -63,6 +63,12 @@ public:
   }
 
 protected:
+  [[deprecated("Use publish(const sensor_msgs::msg::Image&, const PublisherT&) instead.")]]
+  virtual void publish(const sensor_msgs::msg::Image & message, const PublishFn & publish_fn) const
+  {
+    publish_fn(message);
+  }
+
   virtual void publish(const sensor_msgs::msg::Image & message, const PublisherT & publisher) const
   {
     publisher->publish(message);

--- a/image_transport/include/image_transport/raw_publisher.hpp
+++ b/image_transport/include/image_transport/raw_publisher.hpp
@@ -56,10 +56,22 @@ public:
     return "raw";
   }
 
+  virtual bool supportsUniquePtrPub() const
+  {
+    return true;
+  }
+
 protected:
   virtual void publish(const sensor_msgs::msg::Image & message, const PublishFn & publish_fn) const
   {
     publish_fn(message);
+  }
+
+  virtual void publish(
+    sensor_msgs::msg::Image::UniquePtr message,
+    const PublisherT & publisher) const
+  {
+    publisher->publish(std::move(message));
   }
 
   virtual std::string getTopicToAdvertise(const std::string & base_topic) const

--- a/image_transport/include/image_transport/raw_publisher.hpp
+++ b/image_transport/include/image_transport/raw_publisher.hpp
@@ -30,6 +30,7 @@
 #define IMAGE_TRANSPORT__RAW_PUBLISHER_HPP_
 
 #include <string>
+#include <utility>
 
 #include "sensor_msgs/msg/image.hpp"
 

--- a/image_transport/include/image_transport/raw_publisher.hpp
+++ b/image_transport/include/image_transport/raw_publisher.hpp
@@ -63,9 +63,9 @@ public:
   }
 
 protected:
-  virtual void publish(const sensor_msgs::msg::Image & message, const PublishFn & publish_fn) const
+  virtual void publish(const sensor_msgs::msg::Image & message, const PublisherT & publisher) const
   {
-    publish_fn(message);
+    publisher->publish(message);
   }
 
   virtual void publish(

--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -133,8 +133,9 @@ protected:
   typedef std::function<void (const M &)> PublishFn;
 
   /**
-   * \brief Publish an image using the specified publish function. Must be implemented by
-   * the subclass.
+   * \brief Publish an image using the specified publish function.
+   *
+   * \deprecated Use publish(const sensor_msgs::msg::Image&, const PublisherT&) instead.
    *
    * The PublishFn publishes the transport-specific message type. This indirection allows
    * SimpleSubscriberPlugin to use this function for both normal broadcast publishing and
@@ -148,13 +149,25 @@ protected:
       "publish(const sensor_msgs::msg::Image&, const PublishFn&) is not implemented.");
   }
 
+  /**
+   * \brief Publish an image using the specified publisher.
+   */
   virtual void publish(
     const sensor_msgs::msg::Image & message,
     const PublisherT & publisher) const
   {
+    // Fallback to old, deprecated method
     publish(message, bindInternalPublisher(publisher.get()));
   }
 
+  /**
+   * \brief Publish an image using the specified publisher.
+   *
+   * This version of the function can be used to optimize cases where the Plugin can
+   * avoid doing copies of the data when having the ownership to the image message.
+   * Plugins that can take advantage of message ownership should overwrite this method
+   * along with supportsUniquePtrPub().
+   */
   virtual void publish(
     sensor_msgs::msg::Image::UniquePtr /*message*/,
     const PublisherT & /*publisher*/) const

--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -140,8 +140,8 @@ protected:
    * single subscriber publishing (in subscription callbacks).
    */
   virtual void publish(
-    const sensor_msgs::msg::Image & message,
-    const PublishFn & publish_fn) const {}
+    const sensor_msgs::msg::Image & /*message*/,
+    const PublishFn & /*publish_fn*/) const {}
 
   virtual void publish(
     const sensor_msgs::msg::Image & message,

--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -31,6 +31,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "rclcpp/node.hpp"
 #include "rclcpp/logger.hpp"

--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -30,6 +30,7 @@
 #define IMAGE_TRANSPORT__SIMPLE_PUBLISHER_PLUGIN_HPP_
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -141,7 +142,11 @@ protected:
    */
   virtual void publish(
     const sensor_msgs::msg::Image & /*message*/,
-    const PublishFn & /*publish_fn*/) const {}
+    const PublishFn & /*publish_fn*/) const
+  {
+    throw std::logic_error(
+      "publish(const sensor_msgs::msg::Image&, const PublishFn&) is not implemented.");
+  }
 
   virtual void publish(
     const sensor_msgs::msg::Image & message,
@@ -151,10 +156,11 @@ protected:
   }
 
   virtual void publish(
-    sensor_msgs::msg::Image::UniquePtr message,
-    const PublisherT & publisher) const
+    sensor_msgs::msg::Image::UniquePtr /*message*/,
+    const PublisherT & /*publisher*/) const
   {
-    publish(*message, bindInternalPublisher(publisher.get()));
+    throw std::logic_error(
+      "publish(sensor_msgs::msg::Image::UniquePtr, const PublisherT&) is not implemented.");
   }
 
   /**

--- a/image_transport/src/camera_publisher.cpp
+++ b/image_transport/src/camera_publisher.cpp
@@ -154,6 +154,23 @@ void CameraPublisher::publish(
 }
 
 void CameraPublisher::publish(
+  sensor_msgs::msg::Image::UniquePtr image,
+  sensor_msgs::msg::CameraInfo::UniquePtr info) const
+{
+  if (!impl_ || !impl_->isValid()) {
+    // TODO(ros2) Switch to RCUTILS_ASSERT when ros2/rcutils#112 is merged
+    auto logger = impl_ ? impl_->logger_ : rclcpp::get_logger("image_transport");
+    RCLCPP_FATAL(
+      logger,
+      "Call to publish() on an invalid image_transport::CameraPublisher");
+    return;
+  }
+
+  impl_->image_pub_.publish(std::move(image));
+  impl_->info_pub_->publish(std::move(info));
+}
+
+void CameraPublisher::publish(
   sensor_msgs::msg::Image & image, sensor_msgs::msg::CameraInfo & info,
   rclcpp::Time stamp) const
 {
@@ -170,6 +187,26 @@ void CameraPublisher::publish(
   info.header.stamp = stamp;
   impl_->image_pub_.publish(image);
   impl_->info_pub_->publish(info);
+}
+
+void CameraPublisher::publish(
+  sensor_msgs::msg::Image::UniquePtr image,
+  sensor_msgs::msg::CameraInfo::UniquePtr info,
+  rclcpp::Time stamp) const
+{
+  if (!impl_ || !impl_->isValid()) {
+    // TODO(ros2) Switch to RCUTILS_ASSERT when ros2/rcutils#112 is merged
+    auto logger = impl_ ? impl_->logger_ : rclcpp::get_logger("image_transport");
+    RCLCPP_FATAL(
+      logger,
+      "Call to publish() on an invalid image_transport::CameraPublisher");
+    return;
+  }
+
+  image->header.stamp = stamp;
+  info->header.stamp = stamp;
+  impl_->image_pub_.publish(std::move(image));
+  impl_->info_pub_->publish(std::move(info));
 }
 
 void CameraPublisher::shutdown()

--- a/image_transport/src/camera_publisher.cpp
+++ b/image_transport/src/camera_publisher.cpp
@@ -30,6 +30,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "rclcpp/expand_topic_or_service_name.hpp"
 #include "rclcpp/logging.hpp"

--- a/image_transport/src/camera_publisher.cpp
+++ b/image_transport/src/camera_publisher.cpp
@@ -124,7 +124,6 @@ void CameraPublisher::publish(
   const sensor_msgs::msg::CameraInfo & info) const
 {
   if (!impl_ || !impl_->isValid()) {
-    // TODO(ros2) Switch to RCUTILS_ASSERT when ros2/rcutils#112 is merged
     auto logger = impl_ ? impl_->logger_ : rclcpp::get_logger("image_transport");
     RCLCPP_FATAL(
       logger,

--- a/image_transport/src/camera_publisher.cpp
+++ b/image_transport/src/camera_publisher.cpp
@@ -140,7 +140,6 @@ void CameraPublisher::publish(
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info) const
 {
   if (!impl_ || !impl_->isValid()) {
-    // TODO(ros2) Switch to RCUTILS_ASSERT when ros2/rcutils#112 is merged
     auto logger = impl_ ? impl_->logger_ : rclcpp::get_logger("image_transport");
     RCLCPP_FATAL(
       logger,
@@ -157,7 +156,6 @@ void CameraPublisher::publish(
   sensor_msgs::msg::CameraInfo::UniquePtr info) const
 {
   if (!impl_ || !impl_->isValid()) {
-    // TODO(ros2) Switch to RCUTILS_ASSERT when ros2/rcutils#112 is merged
     auto logger = impl_ ? impl_->logger_ : rclcpp::get_logger("image_transport");
     RCLCPP_FATAL(
       logger,
@@ -174,7 +172,6 @@ void CameraPublisher::publish(
   rclcpp::Time stamp) const
 {
   if (!impl_ || !impl_->isValid()) {
-    // TODO(ros2) Switch to RCUTILS_ASSERT when ros2/rcutils#112 is merged
     auto logger = impl_ ? impl_->logger_ : rclcpp::get_logger("image_transport");
     RCLCPP_FATAL(
       logger,
@@ -194,7 +191,6 @@ void CameraPublisher::publish(
   rclcpp::Time stamp) const
 {
   if (!impl_ || !impl_->isValid()) {
-    // TODO(ros2) Switch to RCUTILS_ASSERT when ros2/rcutils#112 is merged
     auto logger = impl_ ? impl_->logger_ : rclcpp::get_logger("image_transport");
     RCLCPP_FATAL(
       logger,

--- a/image_transport/src/publisher.cpp
+++ b/image_transport/src/publisher.cpp
@@ -205,7 +205,6 @@ void Publisher::publish(const sensor_msgs::msg::Image::ConstSharedPtr & message)
 void Publisher::publish(sensor_msgs::msg::Image::UniquePtr message) const
 {
   if (!impl_ || !impl_->isValid()) {
-    // TODO(ros2) Switch to RCUTILS_ASSERT when ros2/rcutils#112 is merged
     auto logger = impl_ ? impl_->logger_ : rclcpp::get_logger("image_transport");
     RCLCPP_FATAL(logger, "Call to publish() on an invalid image_transport::Publisher");
     return;

--- a/image_transport/src/publisher.cpp
+++ b/image_transport/src/publisher.cpp
@@ -202,6 +202,37 @@ void Publisher::publish(const sensor_msgs::msg::Image::ConstSharedPtr & message)
   }
 }
 
+void Publisher::publish(sensor_msgs::msg::Image::UniquePtr message) const
+{
+  if (!impl_ || !impl_->isValid()) {
+    // TODO(ros2) Switch to RCUTILS_ASSERT when ros2/rcutils#112 is merged
+    auto logger = impl_ ? impl_->logger_ : rclcpp::get_logger("image_transport");
+    RCLCPP_FATAL(logger, "Call to publish() on an invalid image_transport::Publisher");
+    return;
+  }
+
+  std::vector<std::shared_ptr<PublisherPlugin>> pubs_take_reference;
+  std::optional<std::shared_ptr<PublisherPlugin>> pub_takes_ownership = std::nullopt;
+
+  for (const auto & pub : impl_->publishers_) {
+    if (pub->getNumSubscribers() > 0) {
+      if (pub->supportsUniquePtrPub() && !pub_takes_ownership.has_value()) {
+        pub_takes_ownership = pub;
+      } else {
+        pubs_take_reference.push_back(pub);
+      }
+    }
+  }
+
+  for (const auto & pub : pubs_take_reference) {
+    pub->publish(*message);
+  }
+
+  if (pub_takes_ownership.has_value()) {
+    pub_takes_ownership.value()->publishUniquePtr(std::move(message));
+  }
+}
+
 void Publisher::shutdown()
 {
   if (impl_) {

--- a/image_transport/src/publisher.cpp
+++ b/image_transport/src/publisher.cpp
@@ -29,6 +29,7 @@
 #include "image_transport/publisher.hpp"
 
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>


### PR DESCRIPTION
ROS2 supports [intra-process communication](https://design.ros2.org/articles/intraprocess_communications.html) when [composing multiple nodes in a single process](https://docs.ros.org/en/iron/Tutorials/Intermediate/Composition.html). It additionally can avoid doing any copies of the data when published using `std::unique_ptr<MessageT>` and subscribed using `shared_ptr<const MessageT>` or `std::unique_ptr<MessageT>` (at most 1 subscriber)

This PR is my attempt to add support for publishing using `std::unique_ptr` without breaking any of the existing APIs.

The idea is that:
1. Each publisher plugin can decide whether they support publishing using unique ptr (for now I don't see how any other plugin than `raw` can take advantage of the ownership).
2. The new `Publisher::publish(sensor_msgs::msg::Image::UniquePtr message)` method first publishes using the const reference to plugins that don't support `std::unique_ptr`, then moves the ownership of the message to (at most 1) plugin that supports it.
3. If there is more than one plugin that supports `std::unique_ptr` and has subscriptions, we pass the ownership to only one such plugin (the first we find), and for the rest we still use const reference, delegating doing any extra copies to plugin implementations.

**Related issues/prs:**
#212
#215
#216 (kinda)