### PR TITLE
Removed warning

### DIFF
--- a/image_transport/src/publisher.cpp
+++ b/image_transport/src/publisher.cpp
@@ -212,7 +212,7 @@ void Publisher::publish(sensor_msgs::msg::Image::UniquePtr message) const
   }
 
   std::vector<std::shared_ptr<PublisherPlugin>> pubs_take_reference;
-  std::optional<std::shared_ptr<PublisherPlugin>> pub_takes_ownership = std::nullopt;
+  std::optional<std::shared_ptr<PublisherPlugin>> pub_takes_ownership{std::nullopt};
 
   for (const auto & pub : impl_->publishers_) {
     if (pub->getNumSubscribers() > 0) {


### PR DESCRIPTION
New warning on `packaging_linux-rhel` https://ci.ros2.org/view/packaging/job/packaging_linux-rhel/1934/clang/new/