### PR TITLE
Preparing for qos deprecation

### DIFF
--- a/image_transport/src/camera_subscriber.cpp
+++ b/image_transport/src/camera_subscriber.cpp
@@ -122,7 +122,8 @@ CameraSubscriber::CameraSubscriber(
   std::string info_topic = getCameraInfoTopic(image_topic);
 
   impl_->image_sub_.subscribe(node, image_topic, transport, custom_qos);
-  impl_->info_sub_.subscribe(node, info_topic, custom_qos);
+  impl_->info_sub_.subscribe(node, info_topic,
+    rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos)));
 
   impl_->sync_.connectInput(impl_->image_sub_, impl_->info_sub_);
   impl_->sync_.registerCallback(std::bind(callback, std::placeholders::_1, std::placeholders::_2));


### PR DESCRIPTION
In preparation for this [`message_filters` PR](https://github.com/ros2/message_filters/pull/127) we should update a `subscribe` method, so that it uses a `rclcpp::QoS` opposed to a `rmw_qos_profile_t`, since that method will become deprecated if the pull request gets merged. Note this will not pass CI until `message_filters` is updated.