### PR TITLE
Use IMAGE_TRANSPORT_PUBLIC at class level for windows gcc build

### DIFF
--- a/image_transport/include/image_transport/camera_publisher.hpp
+++ b/image_transport/include/image_transport/camera_publisher.hpp
@@ -61,13 +61,11 @@ class ImageTransport;
  * associated with that handle will stop being called. Once all CameraPublisher for a
  * given base topic go out of scope the topic (and all subtopics) will be unadvertised.
  */
-class CameraPublisher
+class IMAGE_TRANSPORT_PUBLIC CameraPublisher
 {
 public:
-  IMAGE_TRANSPORT_PUBLIC
   CameraPublisher() = default;
 
-  IMAGE_TRANSPORT_PUBLIC
   CameraPublisher(
     rclcpp::Node * node,
     const std::string & base_topic,
@@ -80,25 +78,21 @@ public:
    *
    * Returns max(image topic subscribers, info topic subscribers).
    */
-  IMAGE_TRANSPORT_PUBLIC
   size_t getNumSubscribers() const;
 
   /*!
    * \brief Returns the base (image) topic of this CameraPublisher.
    */
-  IMAGE_TRANSPORT_PUBLIC
   std::string getTopic() const;
 
   /**
    * \brief Returns the camera info topic of this CameraPublisher.
    */
-  IMAGE_TRANSPORT_PUBLIC
   std::string getInfoTopic() const;
 
   /*!
    * \brief Publish an (image, info) pair on the topics associated with this CameraPublisher.
    */
-  IMAGE_TRANSPORT_PUBLIC
   void publish(
     const sensor_msgs::msg::Image & image,
     const sensor_msgs::msg::CameraInfo & info) const;
@@ -106,7 +100,6 @@ public:
   /*!
    * \brief Publish an (image, info) pair on the topics associated with this CameraPublisher.
    */
-  IMAGE_TRANSPORT_PUBLIC
   void publish(
     const sensor_msgs::msg::Image::ConstSharedPtr & image,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & info) const;
@@ -114,7 +107,6 @@ public:
   /*!
    * \brief Publish an (image, info) pair on the topics associated with this CameraPublisher.
    */
-  IMAGE_TRANSPORT_PUBLIC
   void publish(
     sensor_msgs::msg::Image::UniquePtr image,
     sensor_msgs::msg::CameraInfo::UniquePtr info) const;
@@ -126,7 +118,6 @@ public:
    * Convenience version, which sets the timestamps of both image and info to stamp before
    * publishing.
    */
-  IMAGE_TRANSPORT_PUBLIC
   void publish(
     sensor_msgs::msg::Image & image, sensor_msgs::msg::CameraInfo & info,
     rclcpp::Time stamp) const;
@@ -138,7 +129,6 @@ public:
    * Convenience version, which sets the timestamps of both image and info to stamp before
    * publishing.
    */
-  IMAGE_TRANSPORT_PUBLIC
   void publish(
     sensor_msgs::msg::Image::UniquePtr image,
     sensor_msgs::msg::CameraInfo::UniquePtr info,
@@ -147,19 +137,14 @@ public:
   /*!
    * \brief Shutdown the advertisements associated with this Publisher.
    */
-  IMAGE_TRANSPORT_PUBLIC
   void shutdown();
 
-  IMAGE_TRANSPORT_PUBLIC
   operator void *() const;
 
-  IMAGE_TRANSPORT_PUBLIC
   bool operator<(const CameraPublisher & rhs) const {return impl_ < rhs.impl_;}
 
-  IMAGE_TRANSPORT_PUBLIC
   bool operator!=(const CameraPublisher & rhs) const {return impl_ != rhs.impl_;}
 
-  IMAGE_TRANSPORT_PUBLIC
   bool operator==(const CameraPublisher & rhs) const {return impl_ == rhs.impl_;}
 
 private:

--- a/image_transport/include/image_transport/camera_subscriber.hpp
+++ b/image_transport/include/image_transport/camera_subscriber.hpp
@@ -60,16 +60,14 @@ void callback(const sensor_msgs::msg::Image::ConstSharedPtr&, const sensor_msgs:
  * associated with that handle will stop being called. Once all CameraSubscriber for a given
  * topic go out of scope the topic will be unsubscribed.
  */
-class CameraSubscriber
+class IMAGE_TRANSPORT_PUBLIC CameraSubscriber
 {
 public:
   typedef std::function<void (const sensor_msgs::msg::Image::ConstSharedPtr &,
       const sensor_msgs::msg::CameraInfo::ConstSharedPtr &)> Callback;
 
-  IMAGE_TRANSPORT_PUBLIC
   CameraSubscriber() = default;
 
-  IMAGE_TRANSPORT_PUBLIC
   CameraSubscriber(
     rclcpp::Node * node,
     const std::string & base_topic,
@@ -80,43 +78,34 @@ public:
   /**
    * \brief Get the base topic (on which the raw image is published).
    */
-  IMAGE_TRANSPORT_PUBLIC
   std::string getTopic() const;
 
   /**
    * \brief Get the camera info topic.
    */
-  IMAGE_TRANSPORT_PUBLIC
   std::string getInfoTopic() const;
 
   /**
    * \brief Returns the number of publishers this subscriber is connected to.
    */
-  IMAGE_TRANSPORT_PUBLIC
   size_t getNumPublishers() const;
 
   /**
    * \brief Returns the name of the transport being used.
    */
-  IMAGE_TRANSPORT_PUBLIC
   std::string getTransport() const;
 
   /**
    * \brief Unsubscribe the callback associated with this CameraSubscriber.
    */
-  IMAGE_TRANSPORT_PUBLIC
   void shutdown();
 
-  IMAGE_TRANSPORT_PUBLIC
   operator void *() const;
 
-  IMAGE_TRANSPORT_PUBLIC
   bool operator<(const CameraSubscriber & rhs) const {return impl_ < rhs.impl_;}
 
-  IMAGE_TRANSPORT_PUBLIC
   bool operator!=(const CameraSubscriber & rhs) const {return impl_ != rhs.impl_;}
 
-  IMAGE_TRANSPORT_PUBLIC
   bool operator==(const CameraSubscriber & rhs) const {return impl_ == rhs.impl_;}
 
 private:

--- a/image_transport/include/image_transport/image_transport.hpp
+++ b/image_transport/include/image_transport/image_transport.hpp
@@ -102,29 +102,25 @@ std::vector<std::string> getLoadableTransports();
  * subscribe() functions for creating advertisements and subscriptions of image topics.
 */
 
-class ImageTransport
+class IMAGE_TRANSPORT_PUBLIC ImageTransport
 {
 public:
   using VoidPtr = std::shared_ptr<void>;
   using ImageConstPtr = sensor_msgs::msg::Image::ConstSharedPtr;
   using CameraInfoConstPtr = sensor_msgs::msg::CameraInfo::ConstSharedPtr;
 
-  IMAGE_TRANSPORT_PUBLIC
   explicit ImageTransport(rclcpp::Node::SharedPtr node);
 
-  IMAGE_TRANSPORT_PUBLIC
   ~ImageTransport();
 
   /*!
    * \brief Advertise an image topic, simple version.
    */
-  IMAGE_TRANSPORT_PUBLIC
   Publisher advertise(const std::string & base_topic, uint32_t queue_size, bool latch = false);
 
   /*!
    * \brief Advertise an image topic, simple version.
    */
-  IMAGE_TRANSPORT_PUBLIC
   Publisher advertise(
     const std::string & base_topic, rmw_qos_profile_t custom_qos,
     bool latch = false);
@@ -142,7 +138,6 @@ public:
   /**
    * \brief Subscribe to an image topic, version for arbitrary std::function object.
    */
-  IMAGE_TRANSPORT_PUBLIC
   Subscriber subscribe(
     const std::string & base_topic, uint32_t queue_size,
     const Subscriber::Callback & callback,
@@ -153,7 +148,6 @@ public:
   /**
    * \brief Subscribe to an image topic, version for bare function.
    */
-  IMAGE_TRANSPORT_PUBLIC
   Subscriber subscribe(
     const std::string & base_topic, uint32_t queue_size,
     void (* fp)(const ImageConstPtr &),
@@ -200,7 +194,6 @@ public:
   /**
    * \brief Subscribe to an image topic, version for arbitrary std::function object and QoS.
    */
-  IMAGE_TRANSPORT_PUBLIC
   Subscriber subscribe(
     const std::string & base_topic, rmw_qos_profile_t custom_qos,
     const Subscriber::Callback & callback,
@@ -211,7 +204,6 @@ public:
   /**
    * \brief Subscribe to an image topic, version for bare function.
    */
-  IMAGE_TRANSPORT_PUBLIC
   Subscriber subscribe(
     const std::string & base_topic, rmw_qos_profile_t custom_qos,
     void (* fp)(const ImageConstPtr &),
@@ -258,7 +250,6 @@ public:
   /*!
    * \brief Advertise a synchronized camera raw image + info topic pair, simple version.
    */
-  IMAGE_TRANSPORT_PUBLIC
   CameraPublisher advertiseCamera(
     const std::string & base_topic, uint32_t queue_size,
     bool latch = false);
@@ -283,7 +274,6 @@ public:
    * This version assumes the standard topic naming scheme, where the info topic is
    * named "camera_info" in the same namespace as the base image topic.
    */
-  IMAGE_TRANSPORT_PUBLIC
   CameraSubscriber subscribeCamera(
     const std::string & base_topic, uint32_t queue_size,
     const CameraSubscriber::Callback & callback,
@@ -293,7 +283,6 @@ public:
   /**
    * \brief Subscribe to a synchronized image & camera info topic pair, version for bare function.
    */
-  IMAGE_TRANSPORT_PUBLIC
   CameraSubscriber subscribeCamera(
     const std::string & base_topic, uint32_t queue_size,
     void (* fp)(
@@ -348,13 +337,11 @@ public:
    * \brief Returns the names of all transports declared in the system. Declared
    * transports are not necessarily built or loadable.
    */
-  IMAGE_TRANSPORT_PUBLIC
   std::vector<std::string> getDeclaredTransports() const;
 
   /**
    * \brief Returns the names of all transports that are loadable in the system.
    */
-  IMAGE_TRANSPORT_PUBLIC
   std::vector<std::string> getLoadableTransports() const;
 
 private:

--- a/image_transport/include/image_transport/publisher.hpp
+++ b/image_transport/include/image_transport/publisher.hpp
@@ -62,13 +62,11 @@ namespace image_transport
  * associated with that handle will stop being called. Once all Publisher for a
  * given base topic go out of scope the topic (and all subtopics) will be unadvertised.
  */
-class Publisher
+class IMAGE_TRANSPORT_PUBLIC Publisher
 {
 public:
-  IMAGE_TRANSPORT_PUBLIC
   Publisher() = default;
 
-  IMAGE_TRANSPORT_PUBLIC
   Publisher(
     rclcpp::Node * nh,
     const std::string & base_topic,
@@ -82,49 +80,39 @@ public:
    *
    * Returns the total number of subscribers to all advertised topics.
    */
-  IMAGE_TRANSPORT_PUBLIC
   size_t getNumSubscribers() const;
 
   /*!
    * \brief Returns the base topic of this Publisher.
    */
-  IMAGE_TRANSPORT_PUBLIC
   std::string getTopic() const;
 
   /*!
    * \brief Publish an image on the topics associated with this Publisher.
    */
-  IMAGE_TRANSPORT_PUBLIC
   void publish(const sensor_msgs::msg::Image & message) const;
 
   /*!
    * \brief Publish an image on the topics associated with this Publisher.
    */
-  IMAGE_TRANSPORT_PUBLIC
   void publish(const sensor_msgs::msg::Image::ConstSharedPtr & message) const;
 
   /*!
    * \brief Publish an image on the topics associated with this Publisher.
    */
-  IMAGE_TRANSPORT_PUBLIC
   void publish(sensor_msgs::msg::Image::UniquePtr message) const;
 
   /*!
    * \brief Shutdown the advertisements associated with this Publisher.
    */
-  IMAGE_TRANSPORT_PUBLIC
   void shutdown();
 
-  IMAGE_TRANSPORT_PUBLIC
   operator void *() const;
 
-  IMAGE_TRANSPORT_PUBLIC
   bool operator<(const Publisher & rhs) const {return impl_ < rhs.impl_;}
 
-  IMAGE_TRANSPORT_PUBLIC
   bool operator!=(const Publisher & rhs) const {return impl_ != rhs.impl_;}
 
-  IMAGE_TRANSPORT_PUBLIC
   bool operator==(const Publisher & rhs) const {return impl_ == rhs.impl_;}
 
 private:

--- a/image_transport/include/image_transport/single_subscriber_publisher.hpp
+++ b/image_transport/include/image_transport/single_subscriber_publisher.hpp
@@ -44,7 +44,7 @@ namespace image_transport
  * \brief Allows publication of an image to a single subscriber. Only available inside
  * subscriber connection callbacks.
  */
-class SingleSubscriberPublisher
+class IMAGE_TRANSPORT_PUBLIC SingleSubscriberPublisher
 {
 private:
   SingleSubscriberPublisher(const SingleSubscriberPublisher &) = delete;
@@ -54,25 +54,19 @@ public:
   typedef std::function<size_t ()> GetNumSubscribersFn;
   typedef std::function<void (const sensor_msgs::msg::Image &)> PublishFn;
 
-  IMAGE_TRANSPORT_PUBLIC
   SingleSubscriberPublisher(
     const std::string & caller_id, const std::string & topic,
     const GetNumSubscribersFn & num_subscribers_fn,
     const PublishFn & publish_fn);
 
-  IMAGE_TRANSPORT_PUBLIC
   std::string getSubscriberName() const;
 
-  IMAGE_TRANSPORT_PUBLIC
   std::string getTopic() const;
 
-  IMAGE_TRANSPORT_PUBLIC
   size_t getNumSubscribers() const;
 
-  IMAGE_TRANSPORT_PUBLIC
   void publish(const sensor_msgs::msg::Image & message) const;
 
-  IMAGE_TRANSPORT_PUBLIC
   void publish(const sensor_msgs::msg::Image::ConstSharedPtr & message) const;
 
 private:

--- a/image_transport/include/image_transport/subscriber.hpp
+++ b/image_transport/include/image_transport/subscriber.hpp
@@ -58,15 +58,14 @@ namespace image_transport
  * associated with that handle will stop being called. Once all Subscriber for a given
  * topic go out of scope the topic will be unsubscribed.
  */
-class Subscriber
+class IMAGE_TRANSPORT_PUBLIC Subscriber
 {
 public:
   typedef std::function<void (const sensor_msgs::msg::Image::ConstSharedPtr &)> Callback;
 
-  IMAGE_TRANSPORT_PUBLIC
+  
   Subscriber() = default;
 
-  IMAGE_TRANSPORT_PUBLIC
   Subscriber(
     rclcpp::Node * node,
     const std::string & base_topic,
@@ -82,34 +81,26 @@ public:
    * The Subscriber may actually be subscribed to some transport-specific topic that
    * differs from the base topic.
    */
-  IMAGE_TRANSPORT_PUBLIC
   std::string getTopic() const;
 
   /**
    * \brief Returns the number of publishers this subscriber is connected to.
    */
-  IMAGE_TRANSPORT_PUBLIC
   size_t getNumPublishers() const;
 
   /**
    * \brief Returns the name of the transport being used.
    */
-  IMAGE_TRANSPORT_PUBLIC
   std::string getTransport() const;
 
   /**
    * \brief Unsubscribe the callback associated with this Subscriber.
    */
-  IMAGE_TRANSPORT_PUBLIC
   void shutdown();
 
-  IMAGE_TRANSPORT_PUBLIC
   operator void *() const;
-  IMAGE_TRANSPORT_PUBLIC
   bool operator<(const Subscriber & rhs) const {return impl_ < rhs.impl_;}
-  IMAGE_TRANSPORT_PUBLIC
   bool operator!=(const Subscriber & rhs) const {return impl_ != rhs.impl_;}
-  IMAGE_TRANSPORT_PUBLIC
   bool operator==(const Subscriber & rhs) const {return impl_ == rhs.impl_;}
 
 private:

--- a/image_transport/include/image_transport/subscriber.hpp
+++ b/image_transport/include/image_transport/subscriber.hpp
@@ -63,7 +63,6 @@ class IMAGE_TRANSPORT_PUBLIC Subscriber
 public:
   typedef std::function<void (const sensor_msgs::msg::Image::ConstSharedPtr &)> Callback;
 
-  
   Subscriber() = default;
 
   Subscriber(

--- a/image_transport/include/image_transport/subscriber_filter.hpp
+++ b/image_transport/include/image_transport/subscriber_filter.hpp
@@ -62,7 +62,7 @@ void callback(const std::shared_ptr<const sensor_msgs::msg::Image>&);
 \endverbatim
  */
 
-class SubscriberFilter : public message_filters::SimpleFilter<sensor_msgs::msg::Image>
+class IMAGE_TRANSPORT_PUBLIC SubscriberFilter : public message_filters::SimpleFilter<sensor_msgs::msg::Image>
 {
 public:
   /**
@@ -75,7 +75,6 @@ public:
    * \param queue_size The subscription queue size
    * \param transport The transport hint to pass along
    */
-  IMAGE_TRANSPORT_PUBLIC
   SubscriberFilter(
     rclcpp::Node * node, const std::string & base_topic,
     const std::string & transport)
@@ -86,12 +85,10 @@ public:
   /**
    * \brief Empty constructor, use subscribe() to subscribe to a topic
    */
-  IMAGE_TRANSPORT_PUBLIC
   SubscriberFilter()
   {
   }
 
-  IMAGE_TRANSPORT_PUBLIC
   ~SubscriberFilter()
   {
     unsubscribe();
@@ -105,7 +102,6 @@ public:
    * \param nh The ros::NodeHandle to use to subscribe.
    * \param base_topic The topic to subscribe to.
    */
-  IMAGE_TRANSPORT_PUBLIC
   void subscribe(
     rclcpp::Node * node,
     const std::string & base_topic,
@@ -123,13 +119,11 @@ public:
   /**
    * \brief Force immediate unsubscription of this subscriber from its topic
    */
-  IMAGE_TRANSPORT_PUBLIC
   void unsubscribe()
   {
     sub_.shutdown();
   }
 
-  IMAGE_TRANSPORT_PUBLIC
   std::string getTopic() const
   {
     return sub_.getTopic();
@@ -138,7 +132,6 @@ public:
   /**
    * \brief Returns the number of publishers this subscriber is connected to.
    */
-  IMAGE_TRANSPORT_PUBLIC
   size_t getNumPublishers() const
   {
     return sub_.getNumPublishers();
@@ -147,7 +140,6 @@ public:
   /**
    * \brief Returns the name of the transport being used.
    */
-  IMAGE_TRANSPORT_PUBLIC
   std::string getTransport() const
   {
     return sub_.getTransport();
@@ -156,7 +148,6 @@ public:
   /**
    * \brief Returns the internal image_transport::Subscriber object.
    */
-  IMAGE_TRANSPORT_PUBLIC
   const Subscriber & getSubscriber() const
   {
     return sub_;

--- a/image_transport/include/image_transport/subscriber_filter.hpp
+++ b/image_transport/include/image_transport/subscriber_filter.hpp
@@ -62,7 +62,8 @@ void callback(const std::shared_ptr<const sensor_msgs::msg::Image>&);
 \endverbatim
  */
 
-class IMAGE_TRANSPORT_PUBLIC SubscriberFilter : public message_filters::SimpleFilter<sensor_msgs::msg::Image>
+class IMAGE_TRANSPORT_PUBLIC SubscriberFilter
+  : public message_filters::SimpleFilter<sensor_msgs::msg::Image>
 {
 public:
   /**

--- a/image_transport/include/image_transport/transport_hints.hpp
+++ b/image_transport/include/image_transport/transport_hints.hpp
@@ -42,7 +42,7 @@ namespace image_transport
 /**
  * \brief Stores transport settings for an image topic subscription.
  */
-class TransportHints
+class IMAGE_TRANSPORT_PUBLIC TransportHints
 {
 public:
   /**
@@ -57,7 +57,6 @@ public:
    * @param default_transport Preferred transport to use
    * @param parameter_name The name of the transport parameter
    */
-  IMAGE_TRANSPORT_PUBLIC
   TransportHints(
     const rclcpp::Node * node,
     const std::string & default_transport = "raw",
@@ -66,7 +65,6 @@ public:
     node->get_parameter_or<std::string>(parameter_name, transport_, default_transport);
   }
 
-  IMAGE_TRANSPORT_PUBLIC
   const std::string & getTransport() const
   {
     return transport_;


### PR DESCRIPTION
Hi,

When I compile this project and then some other project which uses this `image_common` on Windows with gcc, I have this kind of error:

>image_transport/image_transport/camera_publisher.hpp:68:3: error: function 'image_transport::CameraPublisher::CameraPublisher()' definition is marked dllimport
   68 |   CameraPublisher() = default;
      |   ^~~~~~~~~~~~~~~

This might be a _gcc_ only issue, when a function is `dllimport` but it has a definition (function body) at the same time.

When I had a similar issue with _gcc_ before, I chose to a safe way by moving the function body from .h to .cpp. But this time it's different since `CameraPublisher() = default;` can only be in the .h file. So in this PR I moved the `IMAGE_TRANSPORT_PUBLIC` from member function level to class level.

There are some places where I can move the function body from .h to .cpp, but to be consistent, class level of `IMAGE_TRANSPORT_PUBLIC` is used for all places.