### PR TITLE
Fix node name

### DIFF
--- a/image_transport/src/republish.cpp
+++ b/image_transport/src/republish.cpp
@@ -44,7 +44,7 @@ namespace image_transport
 {
 
 Republisher::Republisher(const rclcpp::NodeOptions & options)
-: Node("point_cloud_republisher", options)
+: Node("image_republisher", options)
 {
   // Initialize Republishercomponent after construction
   // shared_from_this can't be used in the constructor


### PR DESCRIPTION
Node name appears in logs and confuses readers.

I'm targeting Rolling, but the same change would be useful also in Jazzy.