### PR TITLE
Add optional namespace to /set_camera_info service in CameraInfoManager

### DIFF
--- a/camera_info_manager/include/camera_info_manager/camera_info_manager.hpp
+++ b/camera_info_manager/include/camera_info_manager/camera_info_manager.hpp
@@ -155,6 +155,13 @@ using SetCameraInfo = sensor_msgs::srv::SetCameraInfo;
     will be stored there, missing parent directories being created if
     necessary and possible.
 
+    @par Namespace
+
+    The CameraInfoManager constructor takes an optional namespace
+    argument, which is used to set the ROS namespace for the
+    set_camera_info service. If not provided, the namespace defaults
+    to the private namespace of the node (i.e., "~/set_camera_info").
+
     @par Loading Calibration Data
 
     Prior to Fuerte, calibration information was loaded in the
@@ -178,13 +185,15 @@ public:
   CameraInfoManager(
     rclcpp::Node * node,
     const std::string & cname = "camera",
-    const std::string & url = "");
+    const std::string & url = "",
+    const std::string & ns = "~");
 
   CAMERA_INFO_MANAGER_PUBLIC
   CameraInfoManager(
     rclcpp_lifecycle::LifecycleNode * node,
     const std::string & cname = "camera",
-    const std::string & url = "");
+    const std::string & url = "",
+    const std::string & ns = "~");
 
   CAMERA_INFO_MANAGER_PUBLIC
   CameraInfoManager(
@@ -192,6 +201,7 @@ public:
     rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logger_interface,
     const std::string & cname = "camera", const std::string & url = "",
+    const std::string & ns = "~",
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
 
   CAMERA_INFO_MANAGER_PUBLIC
@@ -272,6 +282,7 @@ private:
   rclcpp::Logger logger_;               ///< logger
   std::string camera_name_;             ///< camera name
   std::string url_;                     ///< URL for calibration data
+  std::string namespace_;               ///< ROS namespace set_camera_info service
   CameraInfo cam_info_;    ///< current CameraInfo
   bool loaded_cam_info_;                ///< cam_info_ load attempted
 };  // class CameraInfoManager

--- a/camera_info_manager/include/camera_info_manager/camera_info_manager.hpp
+++ b/camera_info_manager/include/camera_info_manager/camera_info_manager.hpp
@@ -201,8 +201,8 @@ public:
     rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logger_interface,
     const std::string & cname = "camera", const std::string & url = "",
-    const std::string & ns = "~",
-    rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
+    const std::string & ns = "~");
 
   CAMERA_INFO_MANAGER_PUBLIC
   CameraInfo getCameraInfo(void);

--- a/camera_info_manager/src/camera_info_manager.cpp
+++ b/camera_info_manager/src/camera_info_manager.cpp
@@ -95,7 +95,7 @@ CameraInfoManager::CameraInfoManager(
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logger_interface,
-  const std::string & cname, const std::string & url, 
+  const std::string & cname, const std::string & url,
   rmw_qos_profile_t custom_qos, const std::string & ns)
 : logger_(node_logger_interface->get_logger()),
   camera_name_(cname),

--- a/camera_info_manager/src/camera_info_manager.cpp
+++ b/camera_info_manager/src/camera_info_manager.cpp
@@ -76,7 +76,8 @@ CameraInfoManager::CameraInfoManager(
   rclcpp::Node * node, const std::string & cname,
   const std::string & url, const std::string & ns)
 : CameraInfoManager(node->get_node_base_interface(),
-    node->get_node_services_interface(), node->get_node_logging_interface(), cname, url, ns)
+    node->get_node_services_interface(), node->get_node_logging_interface(), cname, url,
+    rmw_qos_profile_default, ns)
 {
 }
 
@@ -85,7 +86,8 @@ CameraInfoManager::CameraInfoManager(
   const std::string & cname, const std::string & url,
   const std::string & ns)
 : CameraInfoManager(node->get_node_base_interface(),
-    node->get_node_services_interface(), node->get_node_logging_interface(), cname, url, ns)
+    node->get_node_services_interface(), node->get_node_logging_interface(), cname, url,
+    rmw_qos_profile_default, ns)
 {
 }
 
@@ -93,8 +95,8 @@ CameraInfoManager::CameraInfoManager(
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logger_interface,
-  const std::string & cname, const std::string & url, const std::string & ns,
-  rmw_qos_profile_t custom_qos)
+  const std::string & cname, const std::string & url, 
+  rmw_qos_profile_t custom_qos, const std::string & ns)
 : logger_(node_logger_interface->get_logger()),
   camera_name_(cname),
   url_(url),

--- a/camera_info_manager/src/camera_info_manager.cpp
+++ b/camera_info_manager/src/camera_info_manager.cpp
@@ -69,20 +69,23 @@ const std::string
  *           subordinate names, like "left/camera" and "right/camera".
  * @param cname default camera name
  * @param url default Uniform Resource Locator for loading and saving data.
+ * @param ns namespace for the set_camera_info service. If not specified,
+ *           the service name will be "~/set_camera_info".
  */
 CameraInfoManager::CameraInfoManager(
   rclcpp::Node * node, const std::string & cname,
-  const std::string & url)
+  const std::string & url, const std::string & ns)
 : CameraInfoManager(node->get_node_base_interface(),
-    node->get_node_services_interface(), node->get_node_logging_interface(), cname, url)
+    node->get_node_services_interface(), node->get_node_logging_interface(), cname, url, ns)
 {
 }
 
 CameraInfoManager::CameraInfoManager(
   rclcpp_lifecycle::LifecycleNode * node,
-  const std::string & cname, const std::string & url)
+  const std::string & cname, const std::string & url,
+  const std::string & ns)
 : CameraInfoManager(node->get_node_base_interface(),
-    node->get_node_services_interface(), node->get_node_logging_interface(), cname, url)
+    node->get_node_services_interface(), node->get_node_logging_interface(), cname, url, ns)
 {
 }
 
@@ -90,17 +93,20 @@ CameraInfoManager::CameraInfoManager(
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base_interface,
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logger_interface,
-  const std::string & cname, const std::string & url, rmw_qos_profile_t custom_qos)
+  const std::string & cname, const std::string & url, const std::string & ns,
+  rmw_qos_profile_t custom_qos
+  )
 : logger_(node_logger_interface->get_logger()),
   camera_name_(cname),
   url_(url),
+  namespace_(ns),
   loaded_cam_info_(false)
 {
   using namespace std::placeholders;
 
   // register callback for camera calibration service request
   info_service_ = rclcpp::create_service<SetCameraInfo>(
-    node_base_interface, node_services_interface, "~/set_camera_info",
+    node_base_interface, node_services_interface, namespace_ + "/set_camera_info",
     std::bind(&CameraInfoManager::setCameraInfoService, this, _1, _2), custom_qos, nullptr);
 }
 

--- a/camera_info_manager/src/camera_info_manager.cpp
+++ b/camera_info_manager/src/camera_info_manager.cpp
@@ -94,8 +94,7 @@ CameraInfoManager::CameraInfoManager(
   rclcpp::node_interfaces::NodeServicesInterface::SharedPtr node_services_interface,
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logger_interface,
   const std::string & cname, const std::string & url, const std::string & ns,
-  rmw_qos_profile_t custom_qos
-  )
+  rmw_qos_profile_t custom_qos)
 : logger_(node_logger_interface->get_logger()),
   camera_name_(cname),
   url_(url),


### PR DESCRIPTION
Hi,
In the quite common case that one node serves two cameras and where each camera has its own `CameraInfoManager,` there will only be one `/set_camera_info` service that will update both .yaml files which is not ideal. 
Up until Jazzy this could have been remedied by using a sub-node with its custom namespace, however since updating the code to work with lifecycle nodes this is not possible anymore.

I have added a `ns` parameter to `CameraInfoManager` constructors that will be added as a prefix to the `/set_camera_info` service during its creation. As the parameter is optional, without specyfing it `CameraInfoManager` will act as before - the string passed during the creation of the service will be `~/set_camera_info`. This ensures backwards compatibility and would not require anybody to modify their code and this would allow bigger control for users over the name of the service.

This would be great to backport to Jazzy