### PR TITLE
Add in python3-dev build dependency

### DIFF
--- a/image_transport_py/package.xml
+++ b/image_transport_py/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <build_depend>pybind11_vendor</build_depend>
+  <build_depend>python3-dev</build_depend>
 
   <depend>image_transport</depend>
   <depend>rclcpp</depend>


### PR DESCRIPTION
We need this because we call find_package(Python3 Development) in our CMakeLists.txt here.

Also see https://github.com/ros2/ros2_tracing/pull/146#issuecomment-2492724725 for a long explanation of why we need this.