### PR TITLE
Advertise and subscribe with custom qos in Humble

### DIFF
--- a/image_transport/include/image_transport/image_transport.hpp
+++ b/image_transport/include/image_transport/image_transport.hpp
@@ -120,6 +120,14 @@ public:
   Publisher advertise(const std::string & base_topic, uint32_t queue_size, bool latch = false);
 
   /*!
+   * \brief Advertise an image topic, simple version.
+   */
+  IMAGE_TRANSPORT_PUBLIC
+  Publisher advertise(
+    const std::string & base_topic, rmw_qos_profile_t custom_qos,
+    bool latch = false);
+
+  /*!
    * \brief Advertise an image topic with subcriber status callbacks.
    */
   /* TODO(ros2) Implement when SubscriberStatusCallback is available
@@ -238,6 +246,64 @@ public:
   {
     return subscribe(
       base_topic, queue_size, std::bind(fp, obj.get(), std::placeholders::_1),
+      obj, transport_hints, options);
+  }
+
+  /**
+   * \brief Subscribe to an image topic, version for arbitrary std::function object and QoS.
+   */
+  IMAGE_TRANSPORT_PUBLIC
+  Subscriber subscribe(
+    const std::string & base_topic, rmw_qos_profile_t custom_qos,
+    const Subscriber::Callback & callback,
+    const VoidPtr & tracked_object,
+    const TransportHints * transport_hints,
+    const rclcpp::SubscriptionOptions options);
+
+  /**
+   * \brief Subscribe to an image topic, version for bare function.
+   */
+  IMAGE_TRANSPORT_PUBLIC
+  Subscriber subscribe(
+    const std::string & base_topic, rmw_qos_profile_t custom_qos,
+    void (* fp)(const ImageConstPtr &),
+    const TransportHints * transport_hints = nullptr,
+    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
+  {
+    return subscribe(
+      base_topic, custom_qos,
+      std::function<void(const ImageConstPtr &)>(fp),
+      VoidPtr(), transport_hints, options);
+  }
+
+  /**
+   * \brief Subscribe to an image topic, version for class member function with bare pointer.
+   */
+  template<class T>
+  Subscriber subscribe(
+    const std::string & base_topic, rmw_qos_profile_t custom_qos,
+    void (T::* fp)(const ImageConstPtr &), T * obj,
+    const TransportHints * transport_hints = nullptr,
+    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
+  {
+    return subscribe(
+      base_topic, custom_qos, std::bind(fp, obj, std::placeholders::_1),
+      VoidPtr(), transport_hints, options);
+  }
+
+  /**
+   * \brief Subscribe to an image topic, version for class member function with shared_ptr.
+   */
+  template<class T>
+  Subscriber subscribe(
+    const std::string & base_topic, rmw_qos_profile_t custom_qos,
+    void (T::* fp)(const ImageConstPtr &),
+    const std::shared_ptr<T> & obj,
+    const TransportHints * transport_hints = nullptr,
+    const rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
+  {
+    return subscribe(
+      base_topic, custom_qos, std::bind(fp, obj.get(), std::placeholders::_1),
       obj, transport_hints, options);
   }
 

--- a/image_transport/src/image_transport.cpp
+++ b/image_transport/src/image_transport.cpp
@@ -148,6 +148,29 @@ Publisher ImageTransport::advertise(const std::string & base_topic, uint32_t que
   return create_publisher(impl_->node_.get(), base_topic, custom_qos);
 }
 
+Publisher ImageTransport::advertise(
+  const std::string & base_topic, rmw_qos_profile_t custom_qos,
+  bool latch)
+{
+  // TODO(ros2) implement when resolved: https://github.com/ros2/ros2/issues/464
+  (void) latch;
+  return create_publisher(impl_->node_.get(), base_topic, custom_qos);
+}
+
+Subscriber ImageTransport::subscribe(
+  const std::string & base_topic, rmw_qos_profile_t custom_qos,
+  const Subscriber::Callback & callback,
+  const VoidPtr & tracked_object,
+  const TransportHints * transport_hints,
+  const rclcpp::SubscriptionOptions options)
+{
+  (void) tracked_object;
+  return create_subscription(
+    impl_->node_.get(), base_topic, callback,
+    getTransportOrDefault(transport_hints), custom_qos,
+    options);
+}
+
 Subscriber ImageTransport::subscribe(
   const std::string & base_topic, uint32_t queue_size,
   const Subscriber::Callback & callback,

--- a/image_transport/test/test_publisher.cpp
+++ b/image_transport/test/test_publisher.cpp
@@ -83,6 +83,11 @@ TEST_F(TestPublisher, ImageTransportCameraPublisher) {
   auto pub = it.advertiseCamera("camera/image", 1);
 }
 
+TEST_F(TestPublisher, image_transport_camera_publisher_qos) {
+  image_transport::ImageTransport it(node_);
+  auto pub = it.advertise("camera/image", rmw_qos_profile_sensor_data);
+}
+
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);


### PR DESCRIPTION
Introducing custom qos for advertise and subscribe in Humble (ref issue #343). I cherry-picked the original PR commit (#288) and tested it locally.