### PR TITLE
fix: add `rclcpp::shutdown`

### DIFF
--- a/image_transport/test/test_single_subscriber_publisher.cpp
+++ b/image_transport/test/test_single_subscriber_publisher.cpp
@@ -59,7 +59,8 @@ protected:
     node.reset();
   }
 
-  static void TearDownTestSuite() {
+  static void TearDownTestSuite()
+  {
     rclcpp::shutdown();
   }
 

--- a/image_transport/test/test_single_subscriber_publisher.cpp
+++ b/image_transport/test/test_single_subscriber_publisher.cpp
@@ -59,6 +59,9 @@ protected:
     node.reset();
   }
 
+  static void TearDownTestSuite() {
+    rclcpp::shutdown();
+  }
 
   rclcpp::Node::SharedPtr node;
 };


### PR DESCRIPTION
This PR adds the missing `rclcpp::shutdown`.
