### PR TITLE
Draft: Lifecycle support via rclcpp::NodeInterfaces

### DIFF
--- a/image_transport/CMakeLists.txt
+++ b/image_transport/CMakeLists.txt
@@ -118,6 +118,7 @@ if(BUILD_TESTING)
   ament_cppcheck(LANGUAGE "c++")
 
   find_package(ament_cmake_gtest)
+  find_package(rclcpp_lifecycle REQUIRED)
 
   ament_add_gtest(${PROJECT_NAME}-camera_common test/test_camera_common.cpp)
   if(TARGET ${PROJECT_NAME}-camera_common)
@@ -126,7 +127,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(${PROJECT_NAME}-publisher test/test_publisher.cpp)
   if(TARGET ${PROJECT_NAME}-publisher)
-    target_link_libraries(${PROJECT_NAME}-publisher ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}-publisher ${PROJECT_NAME} rclcpp_lifecycle::rclcpp_lifecycle)
   endif()
 
   ament_add_gtest(${PROJECT_NAME}-subscriber test/test_subscriber.cpp)

--- a/image_transport/include/image_transport/camera_publisher.hpp
+++ b/image_transport/include/image_transport/camera_publisher.hpp
@@ -38,6 +38,7 @@
 #include "sensor_msgs/msg/image.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 
+#include "image_transport/node_interfaces.hpp"
 #include "image_transport/single_subscriber_publisher.hpp"
 #include "image_transport/visibility_control.hpp"
 
@@ -69,7 +70,7 @@ public:
 
   IMAGE_TRANSPORT_PUBLIC
   CameraPublisher(
-    rclcpp::Node * node,
+    RequiredInterfaces node_interfaces,
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
     rclcpp::PublisherOptions = rclcpp::PublisherOptions());

--- a/image_transport/include/image_transport/camera_subscriber.hpp
+++ b/image_transport/include/image_transport/camera_subscriber.hpp
@@ -38,6 +38,7 @@
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/image.hpp"
 
+#include "image_transport/node_interfaces.hpp"
 #include "image_transport/visibility_control.hpp"
 
 namespace image_transport
@@ -71,7 +72,7 @@ public:
 
   IMAGE_TRANSPORT_PUBLIC
   CameraSubscriber(
-    rclcpp::Node * node,
+    RequiredInterfaces node_interfaces,
     const std::string & base_topic,
     const Callback & callback,
     const std::string & transport,

--- a/image_transport/include/image_transport/image_transport.hpp
+++ b/image_transport/include/image_transport/image_transport.hpp
@@ -38,6 +38,7 @@
 
 #include "image_transport/camera_publisher.hpp"
 #include "image_transport/camera_subscriber.hpp"
+#include "image_transport/node_interfaces.hpp"
 #include "image_transport/publisher.hpp"
 #include "image_transport/subscriber.hpp"
 #include "image_transport/transport_hints.hpp"
@@ -51,43 +52,86 @@ namespace image_transport
  */
 IMAGE_TRANSPORT_PUBLIC
 Publisher create_publisher(
-  rclcpp::Node * node,
+  RequiredInterfaces node_interfaces,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
   rclcpp::PublisherOptions options = rclcpp::PublisherOptions());
+
+template<typename NodeT>
+IMAGE_TRANSPORT_PUBLIC
+Publisher create_publisher(
+        NodeT * node,
+        const std::string & base_topic,
+        rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
+        rclcpp::PublisherOptions options = rclcpp::PublisherOptions()) {
+    return create_publisher(*node, base_topic, custom_qos, options);
+}
 
 /**
  * \brief Subscribe to an image topic, free function version.
  */
 IMAGE_TRANSPORT_PUBLIC
 Subscriber create_subscription(
-  rclcpp::Node * node,
+  RequiredInterfaces node_interfaces,
   const std::string & base_topic,
   const Subscriber::Callback & callback,
   const std::string & transport,
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
   rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions());
 
+template<typename NodeT>
+IMAGE_TRANSPORT_PUBLIC
+Subscriber create_subscription(
+  NodeT * node,
+  const std::string & base_topic,
+  const Subscriber::Callback & callback,
+  const std::string & transport,
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
+  rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions()) {
+  return create_subscription(*node, base_topic, callback, transport, custom_qos, options);
+}
+
 /*!
  * \brief Advertise a camera, free function version.
  */
 IMAGE_TRANSPORT_PUBLIC
 CameraPublisher create_camera_publisher(
-  rclcpp::Node * node,
+  RequiredInterfaces node_interfaces,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
   rclcpp::PublisherOptions pub_options = rclcpp::PublisherOptions());
+
+template<typename NodeT>
+IMAGE_TRANSPORT_PUBLIC
+CameraPublisher create_camera_publisher(
+  NodeT * node,
+  const std::string & base_topic,
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
+  rclcpp::PublisherOptions pub_options = rclcpp::PublisherOptions()) {
+  return create_camera_publisher(*node, base_topic, custom_qos, pub_options);
+}
 
 /*!
  * \brief Subscribe to a camera, free function version.
  */
 IMAGE_TRANSPORT_PUBLIC
 CameraSubscriber create_camera_subscription(
-  rclcpp::Node * node,
+  RequiredInterfaces node_interfaces,
   const std::string & base_topic,
   const CameraSubscriber::Callback & callback,
   const std::string & transport,
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default);
+
+template<typename NodeT>
+IMAGE_TRANSPORT_PUBLIC
+CameraSubscriber create_camera_subscription(
+  NodeT * node,
+  const std::string & base_topic,
+  const CameraSubscriber::Callback & callback,
+  const std::string & transport,
+  rmw_qos_profile_t custom_qos = rmw_qos_profile_default) {
+  return create_camera_subscription(*node, base_topic, callback, transport, custom_qos);
+}
 
 IMAGE_TRANSPORT_PUBLIC
 std::vector<std::string> getDeclaredTransports();
@@ -110,7 +154,11 @@ public:
   using CameraInfoConstPtr = sensor_msgs::msg::CameraInfo::ConstSharedPtr;
 
   IMAGE_TRANSPORT_PUBLIC
-  explicit ImageTransport(rclcpp::Node::SharedPtr node);
+  explicit ImageTransport(RequiredInterfaces node_interfaces);
+
+  template<typename NodeT>
+  IMAGE_TRANSPORT_PUBLIC
+  explicit ImageTransport(std::shared_ptr<NodeT> node) : ImageTransport(*node) {}
 
   IMAGE_TRANSPORT_PUBLIC
   ImageTransport(const ImageTransport & other);
@@ -372,7 +420,7 @@ private:
 
 struct ImageTransport::Impl
 {
-  rclcpp::Node::SharedPtr node_;
+  RequiredInterfaces node_interfaces_;
 };
 
 }  // namespace image_transport

--- a/image_transport/include/image_transport/node_interfaces.hpp
+++ b/image_transport/include/image_transport/node_interfaces.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2009, Willow Garage, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Willow Garage nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef IMAGE_TRANSPORT__NODE_INTERFACES_HPP
+#define IMAGE_TRANSPORT__NODE_INTERFACES_HPP
+
+#include <rclcpp/node.hpp>
+#include <rclcpp/node_interfaces/node_interfaces.hpp>
+
+namespace image_transport {
+    /**
+     * Collection of node interfaces which are required for the image transport functionality.
+     */
+    using RequiredInterfaces = rclcpp::node_interfaces::NodeInterfaces<rclcpp::node_interfaces::NodeBaseInterface,
+            rclcpp::node_interfaces::NodeLoggingInterface,
+            rclcpp::node_interfaces::NodeTimersInterface,
+            rclcpp::node_interfaces::NodeTopicsInterface,
+            rclcpp::node_interfaces::NodeParametersInterface>;
+}
+
+#endif //IMAGE_TRANSPORT__NODE_INTERFACES_HPP

--- a/image_transport/include/image_transport/publisher.hpp
+++ b/image_transport/include/image_transport/publisher.hpp
@@ -39,6 +39,7 @@
 
 #include "image_transport/exception.hpp"
 #include "image_transport/loader_fwds.hpp"
+#include "image_transport/node_interfaces.hpp"
 #include "image_transport/single_subscriber_publisher.hpp"
 #include "image_transport/visibility_control.hpp"
 
@@ -70,7 +71,7 @@ public:
 
   IMAGE_TRANSPORT_PUBLIC
   Publisher(
-    rclcpp::Node * nh,
+    RequiredInterfaces node_interfaces,
     const std::string & base_topic,
     PubLoaderPtr loader,
     rmw_qos_profile_t custom_qos,

--- a/image_transport/include/image_transport/publisher_plugin.hpp
+++ b/image_transport/include/image_transport/publisher_plugin.hpp
@@ -36,6 +36,7 @@
 #include "rclcpp/node.hpp"
 #include "sensor_msgs/msg/image.hpp"
 
+#include "image_transport/node_interfaces.hpp"
 #include "image_transport/single_subscriber_publisher.hpp"
 #include "image_transport/visibility_control.hpp"
 
@@ -72,12 +73,22 @@ public:
    * \brief Advertise a topic, simple version.
    */
   void advertise(
-    rclcpp::Node * nh,
+    RequiredInterfaces node_interfaces, // TODO: single interface might be enough?
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
     rclcpp::PublisherOptions options = rclcpp::PublisherOptions())
   {
-    advertiseImpl(nh, base_topic, custom_qos, options);
+    advertiseImpl(node_interfaces, base_topic, custom_qos, options);
+  }
+
+  template<typename NodeT>
+  void advertise(
+    NodeT * node,
+    const std::string & base_topic,
+    rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
+    rclcpp::PublisherOptions options = rclcpp::PublisherOptions())
+  {
+    advertiseImpl(*node, base_topic, custom_qos, options);
   }
 
   /**
@@ -156,7 +167,7 @@ protected:
    * \brief Advertise a topic. Must be implemented by the subclass.
    */
   virtual void advertiseImpl(
-    rclcpp::Node * node,
+    RequiredInterfaces node_interfaces, // TODO: could be limited to less interfaces? topic + logger?
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos,
     rclcpp::PublisherOptions options) = 0;

--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -38,6 +38,7 @@
 #include "rclcpp/logger.hpp"
 #include "rclcpp/logging.hpp"
 
+#include "image_transport/node_interfaces.hpp"
 #include "image_transport/publisher_plugin.hpp"
 #include "image_transport/visibility_control.hpp"
 
@@ -114,17 +115,24 @@ public:
 
 protected:
   void advertiseImpl(
-    rclcpp::Node * node,
+    RequiredInterfaces node_interfaces,
     const std::string & base_topic,
     rmw_qos_profile_t custom_qos,
     rclcpp::PublisherOptions options) override
   {
     std::string transport_topic = getTopicToAdvertise(base_topic);
-    simple_impl_ = std::make_unique<SimplePublisherPluginImpl>(node);
+    simple_impl_ = std::make_unique<SimplePublisherPluginImpl>(node_interfaces);
 
     RCLCPP_DEBUG(simple_impl_->logger_, "getTopicToAdvertise: %s", transport_topic.c_str());
     auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
-    simple_impl_->pub_ = node->create_publisher<M>(transport_topic, qos, options);
+
+    // temporary variables are unfortunately necessary due to different passing conventions for shared pointers
+    // between rclcpp core modules for publishers and the node interfaces class
+    auto node_params_interface = node_interfaces.get_node_parameters_interface();
+    auto node_topics_interface = node_interfaces.get_node_topics_interface();
+    simple_impl_->pub_ = rclcpp::create_publisher<M>(node_params_interface,
+                                                     node_topics_interface,
+                                                     transport_topic, qos, options);
   }
 
   typedef typename rclcpp::Publisher<M>::SharedPtr PublisherT;
@@ -189,13 +197,13 @@ protected:
 private:
   struct SimplePublisherPluginImpl
   {
-    explicit SimplePublisherPluginImpl(rclcpp::Node * node)
-    : node_(node),
-      logger_(node->get_logger())
+    explicit SimplePublisherPluginImpl(RequiredInterfaces node_interfaces)
+    : node_interfaces_(node_interfaces),
+      logger_(node_interfaces_.get_node_logging_interface()->get_logger())
     {
     }
 
-    rclcpp::Node * node_;
+    RequiredInterfaces node_interfaces_;
     rclcpp::Logger logger_;
     PublisherT pub_;
   };

--- a/image_transport/include/image_transport/simple_subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/simple_subscriber_plugin.hpp
@@ -109,7 +109,7 @@ protected:
   }
 
   void subscribeImpl(
-    rclcpp::Node * node,
+    RequiredInterfaces node_interfaces,
     const std::string & base_topic,
     const Callback & callback,
     rmw_qos_profile_t custom_qos,
@@ -119,8 +119,11 @@ protected:
     // Push each group of transport-specific parameters into a separate sub-namespace
     // ros::NodeHandle param_nh(transport_hints.getParameterNH(), getTransportName());
     //
+    auto node_params_interface = node_interfaces.get_node_parameters_interface();
+    auto node_topics_interface = node_interfaces.get_node_topics_interface();
     auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
-    impl_->sub_ = node->create_subscription<M>(
+    impl_->sub_ = rclcpp::create_subscription<M>(
+      node_params_interface, node_topics_interface,
       getTopicToSubscribe(base_topic), qos,
       [this, callback](const typename std::shared_ptr<const M> msg) {
         internalCallback(msg, callback);

--- a/image_transport/include/image_transport/subscriber.hpp
+++ b/image_transport/include/image_transport/subscriber.hpp
@@ -38,6 +38,7 @@
 
 #include "image_transport/exception.hpp"
 #include "image_transport/loader_fwds.hpp"
+#include "image_transport/node_interfaces.hpp"
 #include "image_transport/visibility_control.hpp"
 
 namespace image_transport
@@ -68,7 +69,7 @@ public:
 
   IMAGE_TRANSPORT_PUBLIC
   Subscriber(
-    rclcpp::Node * node,
+    RequiredInterfaces node_interfaces,
     const std::string & base_topic,
     const Callback & callback,
     SubLoaderPtr loader,

--- a/image_transport/include/image_transport/subscriber_filter.hpp
+++ b/image_transport/include/image_transport/subscriber_filter.hpp
@@ -37,6 +37,7 @@
 #include "message_filters/simple_filter.hpp"
 
 #include "image_transport/image_transport.hpp"
+#include "image_transport/node_interfaces.hpp"
 #include "image_transport/visibility_control.hpp"
 
 namespace image_transport
@@ -77,10 +78,10 @@ public:
    */
   IMAGE_TRANSPORT_PUBLIC
   SubscriberFilter(
-    rclcpp::Node * node, const std::string & base_topic,
+    RequiredInterfaces node_interfaces, const std::string & base_topic,
     const std::string & transport)
   {
-    subscribe(node, base_topic, transport);
+    subscribe(node_interfaces, base_topic, transport);
   }
 
   /**
@@ -107,7 +108,7 @@ public:
    */
   IMAGE_TRANSPORT_PUBLIC
   void subscribe(
-    rclcpp::Node * node,
+    RequiredInterfaces node_interfaces,
     const std::string & base_topic,
     const std::string & transport,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
@@ -115,7 +116,7 @@ public:
   {
     unsubscribe();
     sub_ = image_transport::create_subscription(
-      node, base_topic,
+      node_interfaces, base_topic,
       std::bind(&SubscriberFilter::cb, this, std::placeholders::_1), transport, custom_qos,
       options);
   }

--- a/image_transport/include/image_transport/subscriber_plugin.hpp
+++ b/image_transport/include/image_transport/subscriber_plugin.hpp
@@ -36,6 +36,7 @@
 #include "rclcpp/node.hpp"
 #include "sensor_msgs/msg/image.hpp"
 
+#include "image_transport/node_interfaces.hpp"
 #include "image_transport/visibility_control.hpp"
 
 namespace image_transport
@@ -65,25 +66,25 @@ public:
    * \brief Subscribe to an image topic, version for arbitrary std::function object.
    */
   void subscribe(
-    rclcpp::Node * node, const std::string & base_topic,
+    RequiredInterfaces node_interfaces, const std::string & base_topic,
     const Callback & callback,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
     rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
   {
-    return subscribeImpl(node, base_topic, callback, custom_qos, options);
+    return subscribeImpl(node_interfaces, base_topic, callback, custom_qos, options);
   }
 
   /**
    * \brief Subscribe to an image topic, version for bare function.
    */
   void subscribe(
-    rclcpp::Node * node, const std::string & base_topic,
+    RequiredInterfaces node_interfaces, const std::string & base_topic,
     void (* fp)(const sensor_msgs::msg::Image::ConstSharedPtr &),
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
     rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
   {
     return subscribe(
-      node, base_topic,
+      node_interfaces, base_topic,
       std::function<void(const sensor_msgs::msg::Image::ConstSharedPtr &)>(fp),
       custom_qos, options);
   }
@@ -93,13 +94,13 @@ public:
    */
   template<class T>
   void subscribe(
-    rclcpp::Node * node, const std::string & base_topic,
+    RequiredInterfaces node_interfaces, const std::string & base_topic,
     void (T::* fp)(const sensor_msgs::msg::Image::ConstSharedPtr &), T * obj,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
     rclcpp::SubscriptionOptions options = rclcpp::SubscriptionOptions())
   {
     return subscribe(
-      node, base_topic,
+      node_interfaces, base_topic,
       std::bind(fp, obj, std::placeholders::_1), custom_qos, options);
   }
 
@@ -108,13 +109,13 @@ public:
    */
   template<class T>
   void subscribe(
-    rclcpp::Node * node, const std::string & base_topic,
+    RequiredInterfaces node_interfaces, const std::string & base_topic,
     void (T::* fp)(const sensor_msgs::msg::Image::ConstSharedPtr &),
     std::shared_ptr<T> & obj,
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default)
   {
     return subscribe(
-      node, base_topic,
+      node_interfaces, base_topic,
       std::bind(fp, obj, std::placeholders::_1), custom_qos);
   }
 
@@ -147,7 +148,7 @@ protected:
    * \brief Subscribe to an image transport topic. Must be implemented by the subclass.
    */
   virtual void subscribeImpl(
-    rclcpp::Node * node,
+    RequiredInterfaces node_interfaces,
     const std::string & base_topic,
     const Callback & callback,
     rmw_qos_profile_t custom_qos,

--- a/image_transport/include/image_transport/transport_hints.hpp
+++ b/image_transport/include/image_transport/transport_hints.hpp
@@ -59,11 +59,14 @@ public:
    */
   IMAGE_TRANSPORT_PUBLIC
   TransportHints(
-    const rclcpp::Node * node,
+    RequiredInterfaces node_interfaces, // TODO: limit to parameters interface?
     const std::string & default_transport = "raw",
     const std::string & parameter_name = "image_transport")
   {
-    node->get_parameter_or<std::string>(parameter_name, transport_, default_transport);
+    rclcpp::Parameter parameter(parameter_name, default_transport);
+
+    parameter = node_interfaces.get_node_parameters_interface()->get_parameter(parameter_name);
+    transport_ = parameter.as_string();
   }
 
   IMAGE_TRANSPORT_PUBLIC

--- a/image_transport/package.xml
+++ b/image_transport/package.xml
@@ -32,6 +32,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rclcpp_lifecycle</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/image_transport/src/camera_publisher.cpp
+++ b/image_transport/src/camera_publisher.cpp
@@ -43,8 +43,8 @@ namespace image_transport
 
 struct CameraPublisher::Impl
 {
-  explicit Impl(rclcpp::Node * node)
-  : logger_(node->get_logger()),
+  explicit Impl(RequiredInterfaces node_interfaces)
+  : logger_(node_interfaces.get_node_logging_interface()->get_logger()),
     unadvertised_(false)
   {
   }
@@ -75,20 +75,21 @@ struct CameraPublisher::Impl
 };
 
 CameraPublisher::CameraPublisher(
-  rclcpp::Node * node,
+  RequiredInterfaces node_interfaces,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos,
   rclcpp::PublisherOptions pub_options)
-: impl_(std::make_shared<Impl>(node))
+: impl_(std::make_shared<Impl>(node_interfaces))
 {
   // Explicitly resolve name here so we compute the correct CameraInfo topic when the
   // image topic is remapped (#4539).
-  std::string image_topic = node->get_node_topics_interface()->resolve_topic_name(base_topic);
+  std::string image_topic = node_interfaces.get_node_topics_interface()->resolve_topic_name(base_topic);
   std::string info_topic = getCameraInfoTopic(image_topic);
 
   auto qos = rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos), custom_qos);
-  impl_->image_pub_ = image_transport::create_publisher(node, image_topic, custom_qos, pub_options);
-  impl_->info_pub_ = node->create_publisher<sensor_msgs::msg::CameraInfo>(info_topic, qos);
+  impl_->image_pub_ = image_transport::create_publisher(node_interfaces, image_topic, custom_qos, pub_options);
+  impl_->info_pub_ = rclcpp::create_publisher<sensor_msgs::msg::CameraInfo>(node_interfaces.get_node_topics_interface(),
+    info_topic, qos);
 }
 
 size_t CameraPublisher::getNumSubscribers() const

--- a/image_transport/src/camera_subscriber.cpp
+++ b/image_transport/src/camera_subscriber.cpp
@@ -35,6 +35,7 @@
 #include "message_filters/time_synchronizer.hpp"
 
 #include "image_transport/camera_common.hpp"
+#include "image_transport/node_interfaces.hpp"
 #include "image_transport/subscriber_filter.hpp"
 
 inline void increment(int * value)
@@ -51,8 +52,8 @@ struct CameraSubscriber::Impl
   using CameraInfo = sensor_msgs::msg::CameraInfo;
   using TimeSync = message_filters::TimeSynchronizer<Image, CameraInfo>;
 
-  explicit Impl(rclcpp::Node * node)
-  : logger_(node->get_logger()),
+  explicit Impl(RequiredInterfaces node_interfaces) // TODO: could be limited to logging interface?
+  : logger_(node_interfaces.get_node_logging_interface()->get_logger()),
     sync_(10),
     unsubscribed_(false),
     image_received_(0), info_received_(0), both_received_(0)
@@ -107,20 +108,20 @@ struct CameraSubscriber::Impl
 };
 
 CameraSubscriber::CameraSubscriber(
-  rclcpp::Node * node,
+  RequiredInterfaces node_interfaces,
   const std::string & base_topic,
   const Callback & callback,
   const std::string & transport,
   rmw_qos_profile_t custom_qos)
-: impl_(std::make_shared<Impl>(node))
+: impl_(std::make_shared<Impl>(node_interfaces))
 {
   // Must explicitly remap the image topic since we then do some string manipulation on it
   // to figure out the sibling camera_info topic.
-  std::string image_topic = node->get_node_topics_interface()->resolve_topic_name(base_topic);
+  std::string image_topic = node_interfaces.get_node_topics_interface()->resolve_topic_name(base_topic);
   std::string info_topic = getCameraInfoTopic(image_topic);
 
-  impl_->image_sub_.subscribe(node, image_topic, transport, custom_qos);
-  impl_->info_sub_.subscribe(node, info_topic,
+  impl_->image_sub_.subscribe(node_interfaces, image_topic, transport, custom_qos);
+  impl_->info_sub_.subscribe(node_interfaces, info_topic,
     rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(custom_qos)));
 
   impl_->sync_.connectInput(impl_->image_sub_, impl_->info_sub_);
@@ -131,9 +132,11 @@ CameraSubscriber::CameraSubscriber(
   impl_->info_sub_.registerCallback(std::bind(increment, &impl_->info_received_));
   impl_->sync_.registerCallback(std::bind(increment, &impl_->both_received_));
 
-  impl_->check_synced_timer_ = node->create_wall_timer(
-    std::chrono::seconds(1),
-    std::bind(&Impl::checkImagesSynchronized, impl_.get()));
+  impl_->check_synced_timer_ = rclcpp::create_wall_timer(std::chrono::seconds(1),
+                                                         std::bind(&Impl::checkImagesSynchronized, impl_.get()),
+                                                         nullptr,
+                                                         node_interfaces.get_node_base_interface().get(),
+                                                         node_interfaces.get_node_timers_interface().get());
 }
 
 std::string CameraSubscriber::getTopic() const

--- a/image_transport/src/image_transport.cpp
+++ b/image_transport/src/image_transport.cpp
@@ -57,42 +57,42 @@ struct Impl
 static Impl * kImpl = new Impl();
 
 Publisher create_publisher(
-  rclcpp::Node * node,
+  RequiredInterfaces node_interfaces,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos,
   rclcpp::PublisherOptions options)
 {
-  return Publisher(node, base_topic, kImpl->pub_loader_, custom_qos, options);
+  return Publisher(node_interfaces, base_topic, kImpl->pub_loader_, custom_qos, options);
 }
 
 Subscriber create_subscription(
-  rclcpp::Node * node,
+  RequiredInterfaces node_interfaces,
   const std::string & base_topic,
   const Subscriber::Callback & callback,
   const std::string & transport,
   rmw_qos_profile_t custom_qos,
   rclcpp::SubscriptionOptions options)
 {
-  return Subscriber(node, base_topic, callback, kImpl->sub_loader_, transport, custom_qos, options);
+  return Subscriber(node_interfaces, base_topic, callback, kImpl->sub_loader_, transport, custom_qos, options);
 }
 
 CameraPublisher create_camera_publisher(
-  rclcpp::Node * node,
+  RequiredInterfaces node_interfaces,
   const std::string & base_topic,
   rmw_qos_profile_t custom_qos,
   rclcpp::PublisherOptions pub_options)
 {
-  return CameraPublisher(node, base_topic, custom_qos, pub_options);
+  return CameraPublisher(node_interfaces, base_topic, custom_qos, pub_options);
 }
 
 CameraSubscriber create_camera_subscription(
-  rclcpp::Node * node,
+  RequiredInterfaces node_interfaces,
   const std::string & base_topic,
   const CameraSubscriber::Callback & callback,
   const std::string & transport,
   rmw_qos_profile_t custom_qos)
 {
-  return CameraSubscriber(node, base_topic, callback, transport, custom_qos);
+  return CameraSubscriber(node_interfaces, base_topic, callback, transport, custom_qos);
 }
 
 std::vector<std::string> getDeclaredTransports()
@@ -131,10 +131,10 @@ std::vector<std::string> getLoadableTransports()
 ImageTransport::ImageTransport(const ImageTransport & other)
 : impl_(std::make_unique<Impl>(*other.impl_)) {}
 
-ImageTransport::ImageTransport(rclcpp::Node::SharedPtr node)
+ImageTransport::ImageTransport(RequiredInterfaces node_interfaces)
 : impl_(std::make_unique<ImageTransport::Impl>())
 {
-  impl_->node_ = node;
+  impl_->node_interfaces_ = std::move(node_interfaces);
 }
 
 ImageTransport::~ImageTransport() = default;
@@ -145,7 +145,7 @@ Publisher ImageTransport::advertise(const std::string & base_topic, uint32_t que
   (void) latch;
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
   custom_qos.depth = queue_size;
-  return create_publisher(impl_->node_.get(), base_topic, custom_qos);
+  return create_publisher(impl_->node_interfaces_, base_topic, custom_qos);
 }
 
 Publisher ImageTransport::advertise(
@@ -154,7 +154,7 @@ Publisher ImageTransport::advertise(
 {
   // TODO(ros2) implement when resolved: https://github.com/ros2/ros2/issues/464
   (void) latch;
-  return create_publisher(impl_->node_.get(), base_topic, custom_qos);
+  return create_publisher(impl_->node_interfaces_, base_topic, custom_qos);
 }
 
 Subscriber ImageTransport::subscribe(
@@ -166,7 +166,7 @@ Subscriber ImageTransport::subscribe(
 {
   (void) tracked_object;
   return create_subscription(
-    impl_->node_.get(), base_topic, callback,
+    impl_->node_interfaces_, base_topic, callback,
     getTransportOrDefault(transport_hints), custom_qos,
     options);
 }
@@ -182,7 +182,7 @@ Subscriber ImageTransport::subscribe(
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
   custom_qos.depth = queue_size;
   return create_subscription(
-    impl_->node_.get(), base_topic, callback,
+    impl_->node_interfaces_, base_topic, callback,
     getTransportOrDefault(transport_hints), custom_qos,
     options);
 }
@@ -195,7 +195,7 @@ CameraPublisher ImageTransport::advertiseCamera(
   (void) latch;
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
   custom_qos.depth = queue_size;
-  return create_camera_publisher(impl_->node_.get(), base_topic, custom_qos);
+  return create_camera_publisher(impl_->node_interfaces_, base_topic, custom_qos);
 }
 
 CameraSubscriber ImageTransport::subscribeCamera(
@@ -208,7 +208,7 @@ CameraSubscriber ImageTransport::subscribeCamera(
   rmw_qos_profile_t custom_qos = rmw_qos_profile_default;
   custom_qos.depth = queue_size;
   return create_camera_subscription(
-    impl_->node_.get(), base_topic, callback,
+    impl_->node_interfaces_, base_topic, callback,
     getTransportOrDefault(transport_hints), custom_qos);
 }
 
@@ -226,7 +226,7 @@ std::string ImageTransport::getTransportOrDefault(const TransportHints * transpo
 {
   std::string ret;
   if (nullptr == transport_hints) {
-    TransportHints th(impl_->node_.get());
+    TransportHints th(impl_->node_interfaces_);
     ret = th.getTransport();
   } else {
     ret = transport_hints->getTransport();

--- a/image_transport/src/publisher.cpp
+++ b/image_transport/src/publisher.cpp
@@ -48,8 +48,8 @@ namespace image_transport
 
 struct Publisher::Impl
 {
-  explicit Impl(rclcpp::Node * node)
-  : logger_(node->get_logger()),
+  explicit Impl(RequiredInterfaces node_interfaces)
+  : logger_(node_interfaces.get_node_logging_interface()->get_logger()),
     unadvertised_(false)
   {
   }
@@ -97,41 +97,45 @@ struct Publisher::Impl
 };
 
 Publisher::Publisher(
-  rclcpp::Node * node, const std::string & base_topic,
+  RequiredInterfaces node_interfaces, const std::string & base_topic,
   PubLoaderPtr loader, rmw_qos_profile_t custom_qos,
   rclcpp::PublisherOptions options)
-: impl_(std::make_shared<Impl>(node))
+: impl_(std::make_shared<Impl>(node_interfaces))
 {
   // Resolve the name explicitly because otherwise the compressed topics don't remap
   // properly (#3652).
-  std::string image_topic = node->get_node_topics_interface()->resolve_topic_name(base_topic);
+  std::string image_topic = node_interfaces.get_node_topics_interface()->resolve_topic_name(base_topic);
   impl_->base_topic_ = image_topic;
   impl_->loader_ = loader;
 
-  auto ns_len = node->get_effective_namespace().length();
+  auto ns_len = strlen(node_interfaces.get_node_base_interface()->get_namespace());
   std::string param_base_name = image_topic.substr(ns_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
   if (param_base_name.front() == '.') {
     param_base_name = param_base_name.substr(1);
   }
+  rclcpp::ParameterValue allowlist_param;
   std::vector<std::string> allowlist_vec;
   std::set<std::string> allowlist;
   std::vector<std::string> all_transport_names;
   for (const auto & lookup_name : loader->getDeclaredClasses()) {
     all_transport_names.emplace_back(erase_last_copy(lookup_name, "_pub"));
   }
+
+  auto node_parameters_interface = node_interfaces.get_node_parameters_interface();
   try {
-    allowlist_vec = node->declare_parameter<std::vector<std::string>>(
-      param_base_name + ".enable_pub_plugins", all_transport_names);
+    allowlist_param = node_parameters_interface->declare_parameter(
+      param_base_name + ".enable_pub_plugins", rclcpp::ParameterValue(all_transport_names));
   } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
     RCLCPP_DEBUG_STREAM(
-      node->get_logger(), param_base_name << ".enable_pub_plugins" << " was previously declared"
+      node_interfaces.get_node_logging_interface()->get_logger(), param_base_name << ".enable_pub_plugins" << " was previously declared"
     );
-    allowlist_vec =
-      node->get_parameter(
-      param_base_name +
-      ".enable_pub_plugins").get_value<std::vector<std::string>>();
+    allowlist_param =
+      node_interfaces.get_node_parameters_interface()->get_parameter(
+              param_base_name +
+              ".enable_pub_plugins").get_parameter_value();
   }
+  allowlist_vec = allowlist_param.get<std::vector<std::string>>();
   for (size_t i = 0; i < allowlist_vec.size(); ++i) {
     allowlist.insert(allowlist_vec[i]);
   }
@@ -140,7 +144,7 @@ Publisher::Publisher(
     const auto & lookup_name = transport_name + "_pub";
     try {
       auto pub = loader->createUniqueInstance(lookup_name);
-      pub->advertise(node, image_topic, custom_qos, options);
+      pub->advertise(node_interfaces, image_topic, custom_qos, options);
       impl_->publishers_.push_back(std::move(pub));
     } catch (const std::runtime_error & e) {
       RCLCPP_ERROR(

--- a/image_transport/src/republish.cpp
+++ b/image_transport/src/republish.cpp
@@ -46,7 +46,7 @@ namespace image_transport
 Republisher::Republisher(const rclcpp::NodeOptions & options)
 : Node("image_republisher", options)
 {
-  // Initialize Republishercomponent after construction
+  // Initialize Republisher component after construction
   // shared_from_this can't be used in the constructor
   this->timer_ = create_wall_timer(
     1ms, [this]() {

--- a/image_transport/src/subscriber.cpp
+++ b/image_transport/src/subscriber.cpp
@@ -45,8 +45,8 @@ namespace image_transport
 
 struct Subscriber::Impl
 {
-  Impl(rclcpp::Node * node, SubLoaderPtr loader)
-  : logger_(node->get_logger()),
+  Impl(RequiredInterfaces node_interfaces, SubLoaderPtr loader)
+  : logger_(node_interfaces.get_node_logging_interface()->get_logger()),
     loader_(loader),
     unsubscribed_(false)
   {
@@ -81,14 +81,14 @@ struct Subscriber::Impl
 };
 
 Subscriber::Subscriber(
-  rclcpp::Node * node,
+  RequiredInterfaces node_interfaces,
   const std::string & base_topic,
   const Callback & callback,
   SubLoaderPtr loader,
   const std::string & transport,
   rmw_qos_profile_t custom_qos,
   rclcpp::SubscriptionOptions options)
-: impl_(std::make_shared<Impl>(node, loader))
+: impl_(std::make_shared<Impl>(node_interfaces, loader))
 {
   // Load the plugin for the chosen transport.
   impl_->lookup_name_ = SubscriberPlugin::getLookupName(transport);
@@ -98,7 +98,7 @@ Subscriber::Subscriber(
     throw TransportLoadException(impl_->lookup_name_, e.what());
   }
 
-  std::string image_topic = node->get_node_topics_interface()->resolve_topic_name(base_topic);
+  std::string image_topic = node_interfaces.get_node_topics_interface()->resolve_topic_name(base_topic);
 
   // Try to catch if user passed in a transport-specific topic as base_topic.
 
@@ -123,7 +123,7 @@ Subscriber::Subscriber(
 
   // Tell plugin to subscribe.
   RCLCPP_DEBUG(impl_->logger_, "Subscribing to: %s\n", image_topic.c_str());
-  impl_->subscriber_->subscribe(node, image_topic, callback, custom_qos, options);
+  impl_->subscriber_->subscribe(node_interfaces, image_topic, callback, custom_qos, options);
 }
 
 std::string Subscriber::getTopic() const

--- a/image_transport/test/test_publisher.cpp
+++ b/image_transport/test/test_publisher.cpp
@@ -32,6 +32,7 @@
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
 
 #include "image_transport/image_transport.hpp"
 
@@ -41,9 +42,11 @@ protected:
   void SetUp()
   {
     node_ = rclcpp::Node::make_shared("test_publisher");
+    lifecycle_node_ = rclcpp_lifecycle::LifecycleNode::make_shared("test_publisher_lifecycle");
   }
 
   rclcpp::Node::SharedPtr node_;
+  rclcpp_lifecycle::LifecycleNode::SharedPtr lifecycle_node_;
 };
 
 TEST_F(TestPublisher, publisher) {
@@ -58,6 +61,11 @@ TEST_F(TestPublisher, publisher) {
 
 TEST_F(TestPublisher, image_transport_publisher) {
   image_transport::ImageTransport it(node_);
+  auto pub = it.advertise("camera/image", 1);
+}
+
+TEST_F(TestPublisher, image_transport_publisher_lifecycle) {
+  image_transport::ImageTransport it(lifecycle_node_);
   auto pub = it.advertise("camera/image", 1);
 }
 


### PR DESCRIPTION
Currently, only a proof of concept, but intended to fix #108 when finished. To keep things simple I started by adding the NodeInterfaces everywhere via pass-by-value, however, changing this in the future should be fairly straightforward.
Corresponding (unfinished) adaptions for the image_transport_plugin repository can be found [here](https://github.com/authaldo/image_transport_plugins/tree/feat_node_interfaces), these are currently limited to the compressed image transport. 

Before progressing further, I would suggest discussing how the two repository situation with `image_common` and `image_transport_plugins` is handled best. Switching to node interfaces within the message filters repository (https://github.com/ros2/message_filters/pull/113) required ensuring backwards compatibility with deprecation warnings. 

Unfortunately, the `rclcpp::Node` pointer  is part of the plugin interface and thus represents an important link between both repositories. Consequently, I am unsure whether backwards compatibility can be ensured here as well.
