### PR TITLE
Revert "Virtualize CameraInfoManager  (#234)"

### DIFF
--- a/camera_info_manager/include/camera_info_manager/camera_info_manager.h
+++ b/camera_info_manager/include/camera_info_manager/camera_info_manager.h
@@ -192,16 +192,15 @@ class CAMERA_INFO_MANAGER_DECL CameraInfoManager
   CameraInfoManager(ros::NodeHandle nh,
                     const std::string &cname="camera",
                     const std::string &url="");
-  virtual ~CameraInfoManager();
-  
-  virtual sensor_msgs::CameraInfo getCameraInfo(void);
-  virtual bool isCalibrated(void);
-  virtual bool loadCameraInfo(const std::string &url);
-  virtual std::string resolveURL(const std::string &url,
-				 const std::string &cname);
-  virtual bool setCameraName(const std::string &cname);
-  virtual bool setCameraInfo(const sensor_msgs::CameraInfo &camera_info);
-  virtual bool validateURL(const std::string &url);
+
+  sensor_msgs::CameraInfo getCameraInfo(void);
+  bool isCalibrated(void);
+  bool loadCameraInfo(const std::string &url);
+  std::string resolveURL(const std::string &url,
+                         const std::string &cname);
+  bool setCameraName(const std::string &cname);
+  bool setCameraInfo(const sensor_msgs::CameraInfo &camera_info);
+  bool validateURL(const std::string &url);
 
  private:
 
@@ -219,24 +218,19 @@ class CAMERA_INFO_MANAGER_DECL CameraInfoManager
 
   // private methods
   std::string getPackageFileName(const std::string &url);
-  virtual bool loadCalibration(const std::string &url,
-			       const std::string &cname);
-  virtual bool loadCalibrationFile(const std::string &filename,
-				   const std::string &cname);
-  virtual bool loadCalibrationFlash(const std::string &flashURL,
-				    const std::string &cname);  
+  bool loadCalibration(const std::string &url,
+                       const std::string &cname);
+  bool loadCalibrationFile(const std::string &filename,
+                           const std::string &cname);
   url_type_t parseURL(const std::string &url);
-  virtual bool saveCalibration(const sensor_msgs::CameraInfo &new_info,
-			       const std::string &url,
-			       const std::string &cname);
-  virtual bool saveCalibrationFile(const sensor_msgs::CameraInfo &new_info,
-				   const std::string &filename,
-				   const std::string &cname);
-  virtual bool saveCalibrationFlash(const sensor_msgs::CameraInfo &new_info,
-				    const std::string &flashURL,
-				    const std::string &cname);  
-  virtual bool setCameraInfoService(sensor_msgs::SetCameraInfo::Request &req,
-				    sensor_msgs::SetCameraInfo::Response &rsp);
+  bool saveCalibration(const sensor_msgs::CameraInfo &new_info,
+                       const std::string &url,
+                       const std::string &cname);
+  bool saveCalibrationFile(const sensor_msgs::CameraInfo &new_info,
+                           const std::string &filename,
+                           const std::string &cname);
+  bool setCameraInfoService(sensor_msgs::SetCameraInfo::Request &req,
+                            sensor_msgs::SetCameraInfo::Response &rsp);
 
   /** @brief mutual exclusion lock for private data
    *

--- a/camera_info_manager/src/camera_info_manager.cpp
+++ b/camera_info_manager/src/camera_info_manager.cpp
@@ -73,8 +73,6 @@ using namespace camera_calibration_parsers;
 const std::string
   default_camera_info_url = "file://${ROS_HOME}/camera_info/${NAME}.yaml";
 
-  CameraInfoManager::~CameraInfoManager() {}
-  
 /** Constructor
  *
  * @param nh node handle, normally for the driver's streaming name
@@ -244,7 +242,7 @@ bool CameraInfoManager::loadCalibration(const std::string &url,
       }
     case URL_flash:
       {
-        success = loadCalibrationFlash(resURL.substr(8), cname);
+        ROS_WARN("[CameraInfoManager] reading from flash not implemented yet");
         break;
       }
     case URL_package:
@@ -303,12 +301,6 @@ bool CameraInfoManager::loadCalibrationFile(const std::string &filename,
     }
 
   return success;
-}
-
-bool CameraInfoManager::loadCalibrationFlash(const std::string &flashURL,
-                                             const std::string &cname) {
-  ROS_WARN("[CameraInfoManager] reading from flash not implemented for this CameraInfoManager");
-  return false;
 }
 
 /** Set a new URL and load its calibration data (if any).
@@ -483,11 +475,6 @@ CameraInfoManager::saveCalibration(const sensor_msgs::CameraInfo &new_info,
           success = saveCalibrationFile(new_info, filename, cname);
         break;
       }
-    case URL_flash:
-      {
-        success = saveCalibrationFlash(new_info, resURL.substr(8), cname);
-        break;  
-      }
     default:
       {
         // invalid URL, save to default location
@@ -499,7 +486,7 @@ CameraInfoManager::saveCalibration(const sensor_msgs::CameraInfo &new_info,
 
   return success;
 }
-
+  
 /** Save CameraInfo calibration data to a file.
  *
  * @pre mutex_ unlocked
@@ -564,13 +551,6 @@ CameraInfoManager::saveCalibrationFile(const sensor_msgs::CameraInfo &new_info,
   // Currently, writeCalibration() always returns true no matter what
   // (ros-pkg ticket #5010).
   return writeCalibration(filename, cname, new_info);
-}
-
-bool CameraInfoManager::saveCalibrationFlash(const sensor_msgs::CameraInfo &new_info,
-                                  const std::string &flashURL,
-                                  const std::string &cname) {
-  ROS_ERROR_STREAM("flash url: " << flashURL << " (ignored)");
-  return saveCalibration(new_info, default_camera_info_url, cname);
 }
 
 /** Callback for SetCameraInfo request.


### PR DESCRIPTION
This reverts commit e9c8c3246007d7717708b5267e1e2e909e4c0694 from #234. It cannot be released into ROS Noetic because changing methods to use `virtual` breaks ABI.

@jdavidberger FYI