### PR TITLE
Fix CameraInfo distortion coefficients and logger

### DIFF
--- a/camera_info_manager_py/camera_info_manager/camera_info_manager.py
+++ b/camera_info_manager_py/camera_info_manager/camera_info_manager.py
@@ -665,7 +665,9 @@ def saveCalibrationFile(ci, filename, cname):
                 return False  # fail if unable to write file
     except OSError as e:
         if e.errno in {errno.EACCES, errno.EPERM}:
-            rclpy.logging.get_logger('camera_info_manager').error('file [' + filename + '] not accessible')
+            rclpy.logging.get_logger('camera_info_manager').error(
+                'file [' + filename + '] not accessible'
+            )
             return False  # unable to write this file
         if e.errno in {errno.ENOENT}:
             # Find last slash in the name.  The URL parser ensures

--- a/camera_info_manager_py/camera_info_manager/camera_info_manager.py
+++ b/camera_info_manager_py/camera_info_manager/camera_info_manager.py
@@ -272,7 +272,7 @@ class CameraInfoManager:
         """
         if self.camera_info is None:
             raise CameraInfoMissingError('Calibration missing, ' + 'loadCameraInfo() needed.')
-        return self.camera_info.K[0] != 0.0
+        return self.camera_info.k[0] != 0.0
 
     def _loadCalibration(self, url, cname):
         """
@@ -486,10 +486,10 @@ def loadCalibrationFile(filename, cname):
                 ci.width = calib['image_width']
                 ci.height = calib['image_height']
                 ci.distortion_model = calib['distortion_model']
-                ci.D = calib['distortion_coefficients']['data']
-                ci.K = calib['camera_matrix']['data']
-                ci.R = calib['rectification_matrix']['data']
-                ci.P = calib['projection_matrix']['data']
+                ci.d = calib['distortion_coefficients']['data']
+                ci.k = calib['camera_matrix']['data']
+                ci.r = calib['rectification_matrix']['data']
+                ci.p = calib['projection_matrix']['data']
 
     except OSError:  # OK if file did not exist
         pass
@@ -649,10 +649,10 @@ def saveCalibrationFile(ci, filename, cname):
         'image_height': ci.height,
         'camera_name': cname,
         'distortion_model': ci.distortion_model,
-        'distortion_coefficients': {'data': ci.D, 'rows': 1, 'cols': len(ci.D)},
-        'camera_matrix': {'data': ci.K, 'rows': 3, 'cols': 3},
-        'rectification_matrix': {'data': ci.R, 'rows': 3, 'cols': 3},
-        'projection_matrix': {'data': ci.P, 'rows': 3, 'cols': 4},
+        'distortion_coefficients': {'data': ci.d, 'rows': 1, 'cols': len(ci.d)},
+        'camera_matrix': {'data': ci.k, 'rows': 3, 'cols': 3},
+        'rectification_matrix': {'data': ci.r, 'rows': 3, 'cols': 3},
+        'projection_matrix': {'data': ci.p, 'rows': 3, 'cols': 4},
     }
 
     # make sure the directory exists and the file is writable

--- a/camera_info_manager_py/camera_info_manager/camera_info_manager.py
+++ b/camera_info_manager_py/camera_info_manager/camera_info_manager.py
@@ -444,7 +444,7 @@ def getPackageFileName(url):
         pkgPath += url[rest:]
 
     except PackageNotFoundError:
-        rclpy.get_logger('camera_info_manager').warning(
+        rclpy.logging.get_logger('camera_info_manager').warning(
             'unknown package: ' + package + ' (ignored)'
         )
 
@@ -473,7 +473,7 @@ def loadCalibrationFile(filename, cname):
             calib = yaml.safe_load(f)
             if calib is not None:
                 if calib['camera_name'] != cname:
-                    rclpy.get_logger('camera_info_manager').warn(
+                    rclpy.logging.get_logger('camera_info_manager').warn(
                         '['
                         + cname
                         + '] does not match name '
@@ -564,7 +564,7 @@ def resolveURL(url, cname):
             if ros_home is None:
                 ros_home = os.environ.get('HOME')
                 if ros_home is None:
-                    rclpy.get_logger('camera_info_manager').warn(
+                    rclpy.logging.get_logger('camera_info_manager').warn(
                         '[CameraInfoManager]' + ' unable to resolve ${ROS_HOME}'
                     )
                     ros_home = '${ROS_HOME}'  # retain it unresolved
@@ -575,7 +575,7 @@ def resolveURL(url, cname):
 
         else:
             # not a valid substitution variable
-            rclpy.get_logger('camera_info_manager').warn(
+            rclpy.logging.get_logger('camera_info_manager').warn(
                 '[CameraInfoManager] invalid URL substitution (not resolved): ' + url
             )
             resolved += '$'  # keep the bogus '$'
@@ -604,7 +604,7 @@ def saveCalibration(new_info, url, cname):
     if url_type == URL_empty:
         return saveCalibration(new_info, default_camera_info_url, cname)
 
-    rclpy.get_logger('camera_info_manager').info(
+    rclpy.logging.get_logger('camera_info_manager').info(
         'writing calibration data to URL: ' + resolved_url
     )
 
@@ -614,7 +614,7 @@ def saveCalibration(new_info, url, cname):
     elif url_type == URL_package:
         filename = getPackageFileName(resolved_url)
         if not filename:  # package not resolved
-            rclpy.get_logger('camera_info_manager').error(
+            rclpy.logging.get_logger('camera_info_manager').error(
                 'Calibration package missing: ' + resolved_url + ' (ignored)'
             )
             # treat it like an empty URL
@@ -623,7 +623,7 @@ def saveCalibration(new_info, url, cname):
             success = saveCalibrationFile(new_info, filename, cname)
 
     else:
-        rclpy.get_logger('camera_info_manager').error(
+        rclpy.logging.get_logger('camera_info_manager').error(
             'Invalid camera calibration URL: ' + resolved_url
         )
         # treat it like an empty URL
@@ -665,14 +665,14 @@ def saveCalibrationFile(ci, filename, cname):
                 return False  # fail if unable to write file
     except OSError as e:
         if e.errno in {errno.EACCES, errno.EPERM}:
-            rclpy.get_logger('camera_info_manager').error('file [' + filename + '] not accessible')
+            rclpy.logging.get_logger('camera_info_manager').error('file [' + filename + '] not accessible')
             return False  # unable to write this file
         if e.errno in {errno.ENOENT}:
             # Find last slash in the name.  The URL parser ensures
             # there is at least one '/', at the beginning.
             last_slash = filename.rfind('/')
             if last_slash < 0:
-                rclpy.get_logger('camera_info_manager').error(
+                rclpy.logging.get_logger('camera_info_manager').error(
                     'filename [' + filename + "] has no '/'"
                 )
                 return False  # not a valid URL
@@ -682,7 +682,7 @@ def saveCalibrationFile(ci, filename, cname):
             try:
                 Path(dirname).mkdir(parents=True)
             except OSError:
-                rclpy.get_logger('camera_info_manager').error(
+                rclpy.logging.get_logger('camera_info_manager').error(
                     'unable to create path to directory [' + dirname + ']'
                 )
                 return False
@@ -694,7 +694,7 @@ def saveCalibrationFile(ci, filename, cname):
                     return True
 
                 except OSError:
-                    rclpy.get_logger('camera_info_manager').error(
+                    rclpy.logging.get_logger('camera_info_manager').error(
                         'file [' + filename + '] not accessible'
                     )
                     return False  # fail if unable to write file

--- a/camera_info_manager_py/camera_info_manager/zoom_camera_info_manager.py
+++ b/camera_info_manager_py/camera_info_manager/zoom_camera_info_manager.py
@@ -206,7 +206,7 @@ class ApproximateZoomCameraInfoManager(ZoomCameraInfoManager):
             return
 
         self.camera_info = deepcopy(self._loaded_camera_info)
-        self.camera_info.K[8] = 1.0
+        self.camera_info.k[8] = 1.0
 
         aspect_ratio = float(self._image_height) / self._image_width
         zoom_percentage = float(self._zoom - self._min_zoom) / float(
@@ -217,33 +217,33 @@ class ApproximateZoomCameraInfoManager(ZoomCameraInfoManager):
             (self._max_fov - self._min_fov) * (1 - zoom_percentage) + self._min_fov
         )
         horizontal_focal_length_in_px = self._image_width / (2 * tan(horizontal_fov / 2))
-        self.camera_info.K[0] = horizontal_focal_length_in_px
+        self.camera_info.k[0] = horizontal_focal_length_in_px
 
         vertical_fov = horizontal_fov * aspect_ratio
         vertical_focal_length_in_px = self._image_height / (2 * tan(vertical_fov / 2))
-        self.camera_info.K[4] = vertical_focal_length_in_px
+        self.camera_info.k[4] = vertical_focal_length_in_px
 
         self.camera_info.width = self._image_width
         self.camera_info.height = self._image_height
 
-        if self._loaded_camera_info.K[2] != 0.0:
+        if self._loaded_camera_info.k[2] != 0.0:
             # if a standard calibration is available, just scale the principal point
             # offset with the resolution
-            self.camera_info.K[2] = (
+            self.camera_info.k[2] = (
                 float(self._image_width)
                 / self._loaded_camera_info.width
-                * self._loaded_camera_info.K[2]
+                * self._loaded_camera_info.k[2]
             )
-            self.camera_info.K[5] = (
+            self.camera_info.k[5] = (
                 float(self._image_height)
                 / self._loaded_camera_info.height
-                * self._loaded_camera_info.K[5]
+                * self._loaded_camera_info.k[5]
             )
         else:
             # if no calibration is available, just set the principal point to lie in
             # the middle of the image
-            self.camera_info.K[2] = self._image_width / 2.0
-            self.camera_info.K[5] = self._image_height / 2.0
+            self.camera_info.k[2] = self._image_width / 2.0
+            self.camera_info.k[5] = self._image_height / 2.0
 
 
 class InterpolatingZoomCameraInfoManager(ZoomCameraInfoManager):
@@ -316,28 +316,28 @@ class InterpolatingZoomCameraInfoManager(ZoomCameraInfoManager):
 
         # linearly interpolate all the matrices
         self.camera_info = deepcopy(self._camera_infos[closest_lower_zoom])
-        self.camera_info.K = [
+        self.camera_info.k = [
             (ratio * low + (1 - ratio) * high)
             for (low, high) in zip(
-                self._camera_infos[closest_lower_zoom].K, self._camera_infos[closest_higher_zoom].K
+                self._camera_infos[closest_lower_zoom].k, self._camera_infos[closest_higher_zoom].k
             )
         ]
-        self.camera_info.P = [
+        self.camera_info.p = [
             (ratio * low + (1 - ratio) * high)
             for (low, high) in zip(
-                self._camera_infos[closest_lower_zoom].P, self._camera_infos[closest_higher_zoom].P
+                self._camera_infos[closest_lower_zoom].p, self._camera_infos[closest_higher_zoom].p
             )
         ]
-        self.camera_info.R = [
+        self.camera_info.r = [
             (ratio * low + (1 - ratio) * high)
             for (low, high) in zip(
-                self._camera_infos[closest_lower_zoom].R, self._camera_infos[closest_higher_zoom].R
+                self._camera_infos[closest_lower_zoom].r, self._camera_infos[closest_higher_zoom].r
             )
         ]
-        self.camera_info.D = [
+        self.camera_info.d = [
             (ratio * low + (1 - ratio) * high)
             for (low, high) in zip(
-                self._camera_infos[closest_lower_zoom].D, self._camera_infos[closest_higher_zoom].D
+                self._camera_infos[closest_lower_zoom].d, self._camera_infos[closest_higher_zoom].d
             )
         ]
 


### PR DESCRIPTION
The `camera_info_manager_py` packages uses the wrong distortion coefficients in the `CameraInfo` message. Additionally `rclpy.get_logger` should be `rclpy.logging.get_logger`.

Fix #354 