### PR TITLE
Fix topic resolution for plugins

### DIFF
--- a/image_transport/include/image_transport/publisher_plugin.hpp
+++ b/image_transport/include/image_transport/publisher_plugin.hpp
@@ -77,7 +77,8 @@ public:
     rmw_qos_profile_t custom_qos = rmw_qos_profile_default,
     rclcpp::PublisherOptions options = rclcpp::PublisherOptions())
   {
-    advertiseImpl(nh, base_topic, custom_qos, options);
+    std::string image_topic = nh->get_node_topics_interface()->resolve_topic_name(base_topic);
+    advertiseImpl(nh, image_topic, custom_qos, options);
   }
 
   /**


### PR DESCRIPTION
Namespace remapping was fixed in #326, but this did not apply to plugins. This commit fixes remapping for any nodes that use a plugin.