### PR TITLE
fix setuptools deprecation

### DIFF
--- a/camera_info_manager_py/setup.py
+++ b/camera_info_manager_py/setup.py
@@ -31,7 +31,7 @@ setup(
                      'drivers similar to the C++ camera_info_manager package.',
     license='BSD',
     extras_require={
-        'test' : [
+        'test': [
             'pytest'
         ]
     },

--- a/camera_info_manager_py/setup.py
+++ b/camera_info_manager_py/setup.py
@@ -22,7 +22,6 @@ setup(
     keywords=['ROS'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
@@ -31,5 +30,9 @@ setup(
                      'This ROS package provides a CameraInfo interface for Python camera\n'
                      'drivers similar to the C++ camera_info_manager package.',
     license='BSD',
-    tests_require=['pytest'],
+    extras_require={
+        'test' : [
+            'pytest'
+        ]
+    },
 )


### PR DESCRIPTION
**FIX:**

#UserWarning: Unknown distribution option: 'tests_require'

**and**

#SetuptoolsDeprecationWarning: License classifiers are deprecated. !!

******************************************************************************** Please consider removing the following classifiers in favor of a SPDX license expression:

License :: OSI Approved :: BSD License

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details. ********************************************************************************