### PR TITLE
fix bugs in SetCameraInfo functions

### DIFF
--- a/camera_info_manager_py/camera_info_manager/camera_info_manager.py
+++ b/camera_info_manager_py/camera_info_manager/camera_info_manager.py
@@ -47,9 +47,9 @@ import locale
 import os
 from pathlib import Path
 
-import numpy as np
 from ament_index_python import get_package_share_directory
 from ament_index_python import PackageNotFoundError
+import numpy as np
 import rclpy
 from rclpy.node import Node
 from sensor_msgs.msg import CameraInfo

--- a/camera_info_manager_py/camera_info_manager/camera_info_manager.py
+++ b/camera_info_manager_py/camera_info_manager/camera_info_manager.py
@@ -53,6 +53,17 @@ from rclpy.node import Node
 from sensor_msgs.msg import CameraInfo
 from sensor_msgs.srv import SetCameraInfo
 import yaml
+import array
+import numpy as np
+
+# tell yaml to serialise array.arrays and np.arrays as simple lists
+# (these hold the matrices and distortion coefficients in CameraInfo)
+
+def ndarray_representer(dumper: yaml.Dumper, array: np.ndarray) -> yaml.Node:
+    return dumper.represent_list(array.tolist())
+
+yaml.SafeDumper.add_representer(np.ndarray, ndarray_representer)    
+yaml.SafeDumper.add_representer(array.array, yaml.representer.Representer.represent_list)
 
 default_camera_info_url = 'file://${ROS_HOME}/camera_info/${NAME}.yaml'
 # parseURL() type codes:
@@ -326,7 +337,7 @@ class CameraInfoManager:
         """
         self._loadCalibration(self.url, self.cname)
 
-    def setCameraInfo(self, req):
+    def setCameraInfo(self, req, rsp):
         """
         Set camera info request callback.
 
@@ -339,7 +350,6 @@ class CameraInfoManager:
         """
         self.node.get_logger().debug('SetCameraInfo received for ' + self.cname)
         self.camera_info = req.camera_info
-        rsp = SetCameraInfo.Response()
         rsp.success = saveCalibration(req.camera_info, self.url, self.cname)
         if not rsp.success:
             rsp.status_message = 'Error storing camera calibration.'

--- a/camera_info_manager_py/camera_info_manager/camera_info_manager.py
+++ b/camera_info_manager_py/camera_info_manager/camera_info_manager.py
@@ -41,12 +41,13 @@ This is very similar to the
 
 """
 
+import array
 import errno
 import locale
 import os
 from pathlib import Path
-import array
 
+import numpy as np
 from ament_index_python import get_package_share_directory
 from ament_index_python import PackageNotFoundError
 import rclpy
@@ -54,7 +55,6 @@ from rclpy.node import Node
 from sensor_msgs.msg import CameraInfo
 from sensor_msgs.srv import SetCameraInfo
 import yaml
-import numpy as np
 
 
 def _ndarray_representer(dumper: yaml.Dumper, array: np.ndarray) -> yaml.Node:

--- a/camera_info_manager_py/camera_info_manager/camera_info_manager.py
+++ b/camera_info_manager_py/camera_info_manager/camera_info_manager.py
@@ -57,14 +57,12 @@ import yaml
 import numpy as np
 
 
-def ndarray_representer(dumper: yaml.Dumper, array: np.ndarray) -> yaml.Node:
-    """
-    This makes yaml output a numpy array as though it were a simple list
-    """
+def _ndarray_representer(dumper: yaml.Dumper, array: np.ndarray) -> yaml.Node:
+    """Make yaml output a numpy array as though it were a simple list."""
     return dumper.represent_list(array.tolist())
 
 
-yaml.SafeDumper.add_representer(np.ndarray, ndarray_representer)    
+yaml.SafeDumper.add_representer(np.ndarray, _ndarray_representer)
 yaml.SafeDumper.add_representer(array.array, yaml.representer.Representer.represent_list)
 
 default_camera_info_url = 'file://${ROS_HOME}/camera_info/${NAME}.yaml'

--- a/camera_info_manager_py/camera_info_manager/camera_info_manager.py
+++ b/camera_info_manager_py/camera_info_manager/camera_info_manager.py
@@ -45,6 +45,7 @@ import errno
 import locale
 import os
 from pathlib import Path
+import array
 
 from ament_index_python import get_package_share_directory
 from ament_index_python import PackageNotFoundError
@@ -53,14 +54,15 @@ from rclpy.node import Node
 from sensor_msgs.msg import CameraInfo
 from sensor_msgs.srv import SetCameraInfo
 import yaml
-import array
 import numpy as np
 
-# tell yaml to serialise array.arrays and np.arrays as simple lists
-# (these hold the matrices and distortion coefficients in CameraInfo)
 
 def ndarray_representer(dumper: yaml.Dumper, array: np.ndarray) -> yaml.Node:
+    """
+    This makes yaml output a numpy array as though it were a simple list
+    """
     return dumper.represent_list(array.tolist())
+
 
 yaml.SafeDumper.add_representer(np.ndarray, ndarray_representer)    
 yaml.SafeDumper.add_representer(array.array, yaml.representer.Representer.represent_list)


### PR DESCRIPTION
Calling the SetCameraInfo service fails for a couple of reasons.

Firstly the function signature for CameraInfoManager.setCameraInfo has changed from

`def setCameraInfo(self, request):`

to

`def setCameraInfo(self, request, response):`

Secondly `yaml.safe_dump` does not accept `array.array` and `numpy.ndarray` which are both used internally by the CameraInfo message type.

This pull request corrects both errors on rolling (may need backporting, but I'm not sure how to do that on github).

Best Wishes,

Phil