### PR TITLE
Removed clang warning

### DIFF
--- a/image_transport/include/image_transport/simple_publisher_plugin.hpp
+++ b/image_transport/include/image_transport/simple_publisher_plugin.hpp
@@ -155,10 +155,7 @@ protected:
    */
   virtual void publish(
     const sensor_msgs::msg::Image & message,
-    const PublisherT & publisher) const
-  {
-    publish(message, publisher);
-  }
+    const PublisherT & publisher) const = 0;
 
   /**
    * \brief Publish an image using the specified publisher.


### PR DESCRIPTION
Related with this error when compiling with clang

```
src/ros-perception/image_common/image_transport/include/image_transport/simple_publisher_plugin.hpp:159:3: warning: all paths through this function will call    
  itself [-Winfinite-recursion]                                                                                                                                                               
    159 |   {      
```