### PR TITLE
Prevent executor race condition

### DIFF
--- a/camera_info_manager/tests/unit_test.cpp
+++ b/camera_info_manager/tests/unit_test.cpp
@@ -72,10 +72,10 @@ protected:
     executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
     executor->add_node(node);
     executor_thread = std::thread([this]() {
-      while (rclcpp::ok() && !canceled_.load()) {
-        executor->spin_once(std::chrono::milliseconds(10));
-      }
-    });
+          while (rclcpp::ok() && !canceled_.load()) {
+            executor->spin_once(std::chrono::milliseconds(10));
+          }
+        });
   }
 
   void TearDown()

--- a/camera_info_manager/tests/unit_test.cpp
+++ b/camera_info_manager/tests/unit_test.cpp
@@ -33,6 +33,7 @@
 #include <unistd.h>
 #endif
 
+#include <atomic>
 #include <chrono>
 #include <filesystem>
 #include <memory>
@@ -57,6 +58,7 @@ class CameraInfoManagerTesting : public ::testing::Test
 protected:
   void SetUp()
   {
+    canceled_ = false;
     const ::testing::TestInfo * const test_info =
       ::testing::UnitTest::GetInstance()->current_test_info();
     std::string node_name = "camera_info_manager_test_" + std::string(test_info->name());
@@ -69,11 +71,16 @@ protected:
     node = rclcpp::Node::make_shared(node_name);
     executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
     executor->add_node(node);
-    executor_thread = std::thread([this]() {executor->spin();});
+    executor_thread = std::thread([this]() {
+      while (rclcpp::ok() && !canceled_.load()) {
+        executor->spin_once(std::chrono::milliseconds(10));
+      }
+    });
   }
 
   void TearDown()
   {
+    canceled_ = true;
     executor->cancel();
     if (executor_thread.joinable()) {
       executor_thread.join();
@@ -102,6 +109,7 @@ protected:
   std::string g_camera_name = "08144361026320a0";
   std::thread executor_thread;
   rclcpp::executors::SingleThreadedExecutor::SharedPtr executor;
+  std::atomic<bool> canceled_;
 };
 
 ///////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description
  
This PR fixes a sporadic hang/deadlock in the camera_info_manager unit tests (https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_repeated/3582/testReport/junit/(root)/projectroot/camera_info_manager_unit_test/)
  
### Root Cause
  
In tests/unit_test.cpp, the CameraInfoManagerTesting fixture spins an executor in a background thread during SetUp():       
  
    executor_thread = std::thread([this]() {executor->spin();});
  
And cancels/joins it during  TearDown() :
  
    executor->cancel();
    executor_thread.join();
  

For very fast test cases, purely synchronous test cases the main thread completes and calls TearDown() almost immediately after SetUp(). This creates a race condition in  rclcpp::Executor:  
  
  1.  TearDown()  calls  executor->cancel() , setting the executor's internal  spinning  atomic flag to  false .
  2. The background thread subsequently starts executing  spin() , which performs  spinning.exchange(true) . This unconditionally   
  sets  spinning  back to  true .
  3. The executor enters the spin loop and blocks on  wait_for_work()  indefinitely, as  cancel()  has already been called. The     
  thread never joins, causing the test suite to hang.
  
  ### Is this user-facing behavior change?
  
  No (test code only).
  
  ### Did you use Generative AI?
  
  Yes, this pull request description and fix were prepared with the assistance of Gemini CLI.
  
  Assisted-by: Gemini CLI:Gemini 3.5 Flash [run_command, view_file, grep_search, replace_file_content]
  
  ### Additional Information

I think this is actually a valid race condition that we are going to potentially need to address in the executor?